### PR TITLE
fix: use `seismic-alloy-core` `v1.4.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ alloy-trie = { version = "0.9.1", default-features = false }
 
 # Serde
 serde_repr = "0.1"
-serde = { version = "=1.0.210", default-features = false, features = [
+serde = { version = "=1.0.220", default-features = false, features = [
     "derive",
     "alloc",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,26 +47,26 @@ revm = { version = "29.0.0", default-features = false }
 seismic-revm = "1.0.0"
 
 # Alloy
-alloy-consensus = { version = "=1.0.30", default-features = false }
-alloy-eips = { version = "=1.0.30", default-features = false }
-alloy-network = { version = "=1.0.30", default-features = false }
-alloy-network-primitives = { version = "=1.0.30", default-features = false }
-alloy-node-bindings = { version = "=1.0.30", default-features = false }
-alloy-provider = { version = "=1.0.30", features = [
+alloy-consensus = { version = "=1.1.0", default-features = false }
+alloy-eips = { version = "=1.1.0", default-features = false }
+alloy-network = { version = "=1.1.0", default-features = false }
+alloy-network-primitives = { version = "=1.1.0", default-features = false }
+alloy-node-bindings = { version = "=1.1.0", default-features = false }
+alloy-provider = { version = "=1.1.0", features = [
     "reqwest",
     "ws",
     "trace-api",
 ] }
-alloy-pubsub = { version = "=1.0.30", default-features = false }
-alloy-rpc-types-eth = { version = "=1.0.30", default-features = false }
-alloy-rpc-types-engine = { version = "=1.0.30", default-features = false }
-alloy-rpc-client = { version = "=1.0.30", default-features = false }
-alloy-rpc-types = { version = "=1.0.30", default-features = false }
-alloy-serde = { version = "=1.0.30", default-features = false }
-alloy-signer = { version = "=1.0.30", default-features = false }
-alloy-signer-local = { version = "=1.0.30", default-features = false }
-alloy-transport = { version = "=1.0.30", default-features = false }
-alloy-genesis = { version = "=1.0.30", default-features = false }
+alloy-pubsub = { version = "=1.1.0", default-features = false }
+alloy-rpc-types-eth = { version = "=1.1.0", default-features = false }
+alloy-rpc-types-engine = { version = "=1.1.0", default-features = false }
+alloy-rpc-client = { version = "=1.1.0", default-features = false }
+alloy-rpc-types = { version = "=1.1.0", default-features = false }
+alloy-serde = { version = "=1.1.0", default-features = false }
+alloy-signer = { version = "=1.1.0", default-features = false }
+alloy-signer-local = { version = "=1.1.0", default-features = false }
+alloy-transport = { version = "=1.1.0", default-features = false }
+alloy-genesis = { version = "=1.1.0", default-features = false }
 
 # Alloy RLP
 alloy-rlp = { version = "0.3.12", default-features = false }
@@ -85,7 +85,7 @@ alloy-trie = { version = "0.9.1", default-features = false }
 
 # Serde
 serde_repr = "0.1"
-serde = { version = "=1.0.220", default-features = false, features = [
+serde = { version = "1.0.226", default-features = false, features = [
     "derive",
     "alloc",
 ] }
@@ -143,35 +143,35 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "12bf284cc6cec2bb49ce24879200dcff16857aa9" }
 
 # seismic-alloy-core
-alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
+alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
 
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "d8425918ced1d62043c3a64b382d6fa1d8c25518" }
 
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-consensus-any = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-rpc-types-any = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.30" }
+# alloy-consensus = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-eips = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-serde = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-network = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-consensus-any = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-rpc-types-any = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-signer = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-provider = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-transport = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
+# alloy-genesis = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
 
 # revm
 revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5df78108a382e66420ad9b815d3f41b5e35f3cc8" }


### PR DESCRIPTION
This PR bumps `seismic-alloy-core` to `1.4.1` to prevent flaky CI and allowing proper building without committing a lockfile