### PR TITLE
fix: correct broken documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Seismic-Alloy provides the transaction types, network abstractions, and provider
 
 Seismic Foundry includes `sanvil` (Seismic Anvil), which is required for the test suite.
 
-For installation instructions, see the [Seismic documentation](https://docs.seismic.systems/getting-started/publish-your-docs#install-the-local-development-suite).
+For installation instructions, see the [Seismic documentation](https://docs.seismic.systems/getting-started/installation#install-the-local-development-suite).
 
 ## Running Tests
 
-**Before running tests**: Install Seismic Anvil (`sanvil`) to run the full test suite. See installation instructions for [sfoundryup](https://docs.seismic.systems/getting-started/publish-your-docs#install-the-local-development-suite).
+**Before running tests**: Install Seismic Anvil (`sanvil`) to run the full test suite. See installation instructions for [sfoundryup](https://docs.seismic.systems/getting-started/installation#install-the-local-development-suite).
 
 Run the full test suite:
 


### PR DESCRIPTION
## Summary

This PR fixes broken documentation links in README.md.

## Changes Made

Fixed two instances of incorrect documentation links:

| Location | Old Path | New Path |
|----------|----------|----------|
| Prerequisites section | \/getting-started/publish-your-docs\ | \/getting-started/installation\ |
| Running Tests section | \/getting-started/publish-your-docs\ | \/getting-started/installation\ |

The old path \publish-your-docs\ doesn't exist in the Seismic documentation. The correct path is \installation\.

## Related Issue

Closes #72

## Testing

- [x] Both links have been verified to work correctly