### PR TITLE
fix(consensus,rpc-types): audit 852 return errors instead of panicking on missing input 

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -430,8 +430,8 @@ impl InputDecryptionElements for SeismicTxEnvelope {
         }
     }
 
-    fn get_input(&self) -> Bytes {
-        self.input().clone()
+    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
+        Ok(self.input().clone())
     }
 
     fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError> {

--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -33,7 +33,7 @@ pub trait InputDecryptionElements: Clone {
     fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError>;
 
     /// Returns the 'input' field of the transaction.
-    fn get_input(&self) -> Bytes;
+    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError>;
 
     /// Sets the 'input' field of the transaction to the provided data.
     fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError>;
@@ -51,10 +51,12 @@ pub trait InputDecryptionElements: Clone {
         let mut tx = self.clone();
         if let Ok(seismic_elements) = tx.get_decryption_elements() {
             let tx_metadata = self.metadata(sender)?;
-            let ciphertext = tx.get_input();
+            let ciphertext = tx.get_input()?;
             let decrypted_data = seismic_elements
                 .decrypt(decryption_key, &ciphertext, &tx_metadata)
-                .map_err(|e| InputDecryptionElementsError::DecryptionError(e.to_string()))?;
+                .map_err(|e| {
+                    InputDecryptionElementsError::DecryptionError(e.to_string())
+                })?;
             tx.set_input(Bytes::from(decrypted_data))?;
         }
         Ok(tx)
@@ -107,7 +109,7 @@ where
         self.inner.get_decryption_elements()
     }
 
-    fn get_input(&self) -> alloy_primitives::Bytes {
+    fn get_input(&self) -> Result<alloy_primitives::Bytes, InputDecryptionElementsError> {
         self.inner.get_input()
     }
 
@@ -776,8 +778,8 @@ impl InputDecryptionElements for TxSeismic {
         Ok(self.seismic_elements)
     }
 
-    fn get_input(&self) -> Bytes {
-        self.input.clone()
+    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
+        Ok(self.input.clone())
     }
 
     fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError> {

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -440,8 +440,8 @@ impl InputDecryptionElements for SeismicTypedTransaction {
         }
     }
 
-    fn get_input(&self) -> Bytes {
-        self.input().clone()
+    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
+        Ok(self.input().clone())
     }
 
     fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError> {

--- a/crates/network/src/foundry/envelope.rs
+++ b/crates/network/src/foundry/envelope.rs
@@ -380,11 +380,11 @@ impl InputDecryptionElements for SeismicFoundryTxEnvelope {
         }
     }
 
-    fn get_input(&self) -> Bytes {
+    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
         match self {
             SeismicFoundryTxEnvelope::Seismic(tx) => tx.tx().get_input(),
-            SeismicFoundryTxEnvelope::Ethereum(tx) => tx.input().clone(),
-            SeismicFoundryTxEnvelope::Unknown(tx) => tx.input().clone(),
+            SeismicFoundryTxEnvelope::Ethereum(tx) => Ok(tx.input().clone()),
+            SeismicFoundryTxEnvelope::Unknown(tx) => Ok(tx.input().clone()),
         }
     }
 

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -690,4 +690,36 @@ mod tests {
         let end_input = req.get_input();
         assert_eq!(data, end_input);
     }
+
+    /// Regression test: get_input() must return an error instead of panicking
+    /// when called on a SeismicTransactionRequest with no input data.
+    #[test]
+    fn get_input_returns_error_when_input_missing() {
+        let req = SeismicTransactionRequest::default()
+            .from(Address::ZERO)
+            .nonce(0)
+            .to(Address::ZERO)
+            .seismic_elements(TxSeismicElements::default())
+            .seismic();
+
+        let result = req.get_input();
+        assert!(result.is_err(), "get_input should return Err when input is missing");
+    }
+
+    /// Regression test: to_transaction_request() must return an error instead of
+    /// panicking when seismic elements are present but calldata is missing.
+    #[test]
+    fn to_transaction_request_returns_error_when_input_missing() {
+        let mut req = SeismicTransactionRequest::default()
+            .from(Address::ZERO)
+            .nonce(0)
+            .to(Address::ZERO)
+            .seismic_elements(TxSeismicElements::default())
+            .seismic();
+        req.inner.chain_id = Some(1);
+
+        let sk = seismic_enclave::get_unsecure_sample_secp256k1_sk();
+        let result = req.to_transaction_request(&sk);
+        assert!(result.is_err(), "to_transaction_request should return Err when input is missing");
+    }
 }

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -230,11 +230,15 @@ impl SeismicTransactionRequest {
                 }
             };
             let tx_metadata = self.metadata(sender)?;
-            let ciphertext = self.inner.input.input().unwrap();
-            let plaintext = tx_metadata
-                .decrypt(secret_key, ciphertext)
-                .map_err(|e| InputDecryptionElementsError::DecryptionError(e.to_string()))?;
-            return Ok(self.inner.clone().input(alloy_primitives::Bytes::from(plaintext).into()));
+            return match self.inner.input.input() {
+                Some(ciphertext) => {
+                    let plaintext = tx_metadata.decrypt(secret_key, ciphertext).map_err(|e| {
+                        InputDecryptionElementsError::DecryptionError(e.to_string())
+                    })?;
+                    Ok(self.inner.clone().input(alloy_primitives::Bytes::from(plaintext).into()))
+                }
+                None => Err(InputDecryptionElementsError::MissingField("input")),
+            };
         }
         return Err(InputDecryptionElementsError::NoElements);
     }
@@ -555,8 +559,11 @@ impl InputDecryptionElements for SeismicTransactionRequest {
         self.seismic_elements.ok_or(InputDecryptionElementsError::NoElements)
     }
 
-    fn get_input(&self) -> Bytes {
-        self.inner.input.clone().into_input().unwrap()
+    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
+        match self.inner.input.clone().into_input() {
+            Some(input) => Ok(input),
+            None => Err(InputDecryptionElementsError::MissingField("input")),
+        }
     }
 
     fn set_input(
@@ -682,12 +689,12 @@ mod tests {
     #[test]
     fn test_set_input_for_request() {
         let mut req = SeismicTransactionRequest::from_transaction(TxEip1559::default());
-        let start_input = req.get_input();
+        let start_input = req.get_input().unwrap();
         let data = Bytes::from("test");
         assert_ne!(data, start_input);
 
         req.set_input(data.clone()).unwrap();
-        let end_input = req.get_input();
+        let end_input = req.get_input().unwrap();
         assert_eq!(data, end_input);
     }
 


### PR DESCRIPTION
- **test(rpc-types): add regression tests for missing input panics**
- **fix(consensus,rpc-types): return errors instead of panicking on missing input**
