### PR TITLE
feat: add seismic-alloy-trie minimal crate (part of no-trie-fork)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ seismic-enclave =  { git = "https://github.com/SeismicSystems/enclave.git", rev 
 
 # seismic-alloy-core
 # TODO(samlaf): pointing to https://github.com/SeismicSystems/seismic-alloy-core/pull/58
-# Before merging this PR, merge the one from seismic-alloy-core and update the rev here.
+# Before merging this PR, merge that PR and update the rev here.
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
 alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ seismic-alloy-rpc-types = { version = "0.0.1", path = "crates/rpc-types", defaul
 seismic-alloy-network = { version = "0.0.1", path = "crates/network", default-features = false }
 seismic-alloy-provider = { version = "0.0.1", path = "crates/provider", default-features = false }
 seismic-prelude = { version = "0.0.1", path = "crates/prelude" }
+seismic-alloy-trie = { version = "0.0.1", path = "crates/trie", default-features = false }
 
 seismic-enclave = "0.1.0"
 
@@ -146,15 +147,22 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 seismic-enclave =  { git = "https://github.com/SeismicSystems/enclave.git", rev = "f90b02f38a6190e8b2ff2d051d9043f3480cd3ac" }
 
 # seismic-alloy-core
-alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
-alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
-alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
-alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
-alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
-alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
-alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
-
-alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
+# TODO(samlaf): pointing to https://github.com/SeismicSystems/seismic-alloy-core/pull/58
+# Before merging this PR, merge the one from seismic-alloy-core and update the rev here.
+alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", branch = "feat--no-trie-fork" }
+# alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
+# alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "690360686c2842acb8456cb632ddbfcf72c51790" }
 
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }

--- a/crates/genesis/Cargo.toml
+++ b/crates/genesis/Cargo.toml
@@ -26,6 +26,7 @@ workspace = true
 alloy-primitives.workspace = true
 alloy-serde.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }
+seismic-alloy-trie.workspace = true
 alloy-genesis = { workspace = true }
 
 # serde

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -336,7 +336,7 @@ impl From<GenesisAccount> for TrieAccount {
         let storage_root = account
             .storage
             .map(|storage| {
-                alloy_trie::root::storage_root_unhashed(
+                seismic_alloy_trie::storage_root_unhashed(
                     storage.into_iter().filter(|(_, value)| !value.is_zero()),
                 )
             })

--- a/crates/trie/Cargo.toml
+++ b/crates/trie/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "seismic-alloy-trie"
+description = "Seismic storage trie root functions (FlaggedStorage-aware)"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives.workspace = true
+alloy-rlp.workspace = true
+alloy-trie = { workspace = true, features = ["ethereum"] }
+
+[features]
+default = ["std"]
+std = [
+    "alloy-primitives/std",
+    "alloy-rlp/std",
+    "alloy-trie/std",
+]

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -10,7 +10,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use alloy_primitives::{B256, FlaggedStorage, keccak256};
+use alloy_primitives::{keccak256, FlaggedStorage, B256};
 use alloy_trie::{HashBuilder, Nibbles};
 
 /// Hashes storage keys, sorts them, and calculates the root hash of the storage trie.
@@ -43,16 +43,11 @@ pub fn storage_root_unsorted<T: Into<FlaggedStorage>>(
 /// # Panics
 ///
 /// If the items are not in sorted order.
-pub fn storage_root<T: Into<FlaggedStorage>>(
-    storage: impl IntoIterator<Item = (B256, T)>,
-) -> B256 {
+pub fn storage_root<T: Into<FlaggedStorage>>(storage: impl IntoIterator<Item = (B256, T)>) -> B256 {
     let mut hb = HashBuilder::default();
     for (hashed_slot, value) in storage {
         let value: FlaggedStorage = value.into();
-        hb.add_leaf(
-            Nibbles::unpack(hashed_slot),
-            alloy_rlp::encode_fixed_size(&value).as_ref(),
-        );
+        hb.add_leaf(Nibbles::unpack(hashed_slot), alloy_rlp::encode_fixed_size(&value).as_ref());
     }
     hb.root()
 }

--- a/crates/trie/src/lib.rs
+++ b/crates/trie/src/lib.rs
@@ -1,0 +1,58 @@
+//! Seismic storage trie root functions.
+//!
+//! These replace the upstream `alloy_trie::root::storage_root*` functions with
+//! versions that accept [`FlaggedStorage`] values. The `is_private` flag is
+//! encoded into the leaf value bytes via `FlaggedStorage`'s RLP `Encodable` impl,
+//! so no fork of `alloy-trie` is needed.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use alloy_primitives::{B256, FlaggedStorage, keccak256};
+use alloy_trie::{HashBuilder, Nibbles};
+
+/// Hashes storage keys, sorts them, and calculates the root hash of the storage trie.
+///
+/// Accepts any value type that converts to [`FlaggedStorage`], so both `U256` (public)
+/// and `FlaggedStorage` work. See [`storage_root`] for encoding details.
+pub fn storage_root_unhashed<T: Into<FlaggedStorage>>(
+    storage: impl IntoIterator<Item = (B256, T)>,
+) -> B256 {
+    storage_root_unsorted(storage.into_iter().map(|(slot, value)| (keccak256(slot), value)))
+}
+
+/// Sorts and calculates the root hash of account storage trie.
+///
+/// See [`storage_root`] for encoding details.
+pub fn storage_root_unsorted<T: Into<FlaggedStorage>>(
+    storage: impl IntoIterator<Item = (B256, T)>,
+) -> B256 {
+    let mut v = Vec::from_iter(storage);
+    v.sort_unstable_by_key(|(key, _)| *key);
+    storage_root(v)
+}
+
+/// Calculates the root hash of account storage trie.
+///
+/// The `is_private` flag is encoded into the leaf value bytes via
+/// `FlaggedStorage`'s RLP `Encodable` impl: public values encode identically
+/// to bare `U256`, while private values append an extra `0x01` byte.
+///
+/// # Panics
+///
+/// If the items are not in sorted order.
+pub fn storage_root<T: Into<FlaggedStorage>>(
+    storage: impl IntoIterator<Item = (B256, T)>,
+) -> B256 {
+    let mut hb = HashBuilder::default();
+    for (hashed_slot, value) in storage {
+        let value: FlaggedStorage = value.into();
+        hb.add_leaf(
+            Nibbles::unpack(hashed_slot),
+            alloy_rlp::encode_fixed_size(&value).as_ref(),
+        );
+    }
+    hb.root()
+}


### PR DESCRIPTION
Related to:
- https://github.com/SeismicSystems/seismic-alloy-core/pull/58
- https://github.com/SeismicSystems/seismic-alloy/pull/80
- https://github.com/SeismicSystems/seismic-reth/pull/370

## DO NOT MERGE

> We probably will want to only merge this after the audit is done, unless we decide we want to pull the trigger and want it audited.

This adds a new minimal seismic-alloy-trie wrapper crate around alloy-trie. alloy-trie has functions to compute the storage state root, but they take `into<U256>` as arguments. We want to be passing FlaggedStorage, so instead of forking alloy-trie like we previously did, I'm adding equivalent functions here that we should use in reth (and foundry?) instead.

See design in https://hackmd.io/ZOGfcUP2SyKmPeOuz0tmvg