### PR TITLE
ci(seismic): make CI run on all PRs

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -3,13 +3,15 @@ on:
   push:
     branches: [seismic]
   pull_request:
-    branches: [seismic, dev]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've been creating some PRs against the veridise-audit-feb-2026 branch, and I noticed that CI has not been running, which is not good.