### PR TITLE
refactor(cargo.toml): delete unused alloy-compat feature

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -22,7 +22,6 @@ alloy-primitives = { workspace = true, features = ["rlp", "seismic"] }
 alloy-consensus.workspace = true
 alloy-rlp.workspace = true
 alloy-serde = { workspace = true, optional = true }
-alloy-network = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-dyn-abi = { workspace = true, features = ["eip712", "seismic"]}
 
@@ -72,7 +71,6 @@ std = [
     "alloy-consensus/std",
     "derive_more/std",
 ]
-alloy-compat = ["serde", "dep:alloy-network", "dep:alloy-rpc-types-eth"]
 k256 = ["alloy-primitives/k256", "alloy-consensus/k256"]
 kzg = ["alloy-eips/kzg", "alloy-consensus/kzg", "std"]
 arbitrary = [


### PR DESCRIPTION
Just a small cleanup PR.
Similar to https://github.com/SeismicSystems/seismic-reth/pull/333, see reasoning there.