### PR TITLE
ci: run tests on github ci instead of self-hosted runner

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -58,7 +58,7 @@ jobs:
       # Would be nice also to run the provider integration tests against the latest stable and latest nightly version (sfoundryup -i nightly) of sanvil.
       - name: Install sfoundry (sanvil)
         run: |
-          curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash && sfoundryup
+          curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
           echo $PATH
           echo $XDG_CONFIG_HOME
           echo "$HOME/.seismic/bin" >> $GITHUB_PATH

--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -45,22 +45,21 @@ jobs:
       - name: cargo check warnings
         run: RUSTFLAGS="-D warnings" cargo check
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      CARGO_HOME: /home/azureuser/.cargo
-      RUSTUP_HOME: /home/azureuser/.rustup
-      HOME: /home/azureuser
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Setup sanvil PATH
-        run: |
-          echo "$HOME/.seismic/bin" >> $GITHUB_PATH
-          echo "sanvil path configured"
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "test-cache"
-      - name: cargo test
+      # Install sfoundry for sanvil. The provider tests are integration tests that start `sanvil` so we need to add it to the PATH.
+      # TODO(samlaf): We probably would want to separate unit tests from integration tests to be able to run unit tests without dependencies.
+      # Would be nice also to run the provider integration tests against the latest stable and latest nightly version (sfoundryup -i nightly) of sanvil.
+      - name: Install sfoundry (sanvil)
         run: |
-          cargo test --workspace
+          curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
+          ~/.seismic/bin/sfoundryup
+          echo "$HOME/.seismic/bin" >> $GITHUB_PATH
+      - name: cargo test
+        run: cargo test --workspace

--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -60,8 +60,7 @@ jobs:
         run: |
           curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
           SEISMIC_BIN="${XDG_CONFIG_HOME:-$HOME}/.seismic/bin"
-          export PATH="$SEISMIC_BIN:$PATH"
-          sfoundryup
+          $SEISMIC_BIN/sfoundryup
           echo "$SEISMIC_BIN" >> $GITHUB_PATH
       - name: cargo test
         run: cargo test --workspace

--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -58,7 +58,7 @@ jobs:
       # Would be nice also to run the provider integration tests against the latest stable and latest nightly version (sfoundryup -i nightly) of sanvil.
       - name: Install sfoundry (sanvil)
         run: |
-          curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/foundryup | bash && sfoundryup
+          curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash && sfoundryup
           echo "$HOME/.seismic/bin" >> $GITHUB_PATH
       - name: cargo test
         run: cargo test --workspace

--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Install sfoundry (sanvil)
         run: |
           curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash && sfoundryup
+          echo $PATH
+          echo $XDG_CONFIG_HOME
           echo "$HOME/.seismic/bin" >> $GITHUB_PATH
       - name: cargo test
         run: cargo test --workspace

--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -59,8 +59,9 @@ jobs:
       - name: Install sfoundry (sanvil)
         run: |
           curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
-          echo $PATH
-          echo $XDG_CONFIG_HOME
-          echo "$HOME/.seismic/bin" >> $GITHUB_PATH
+          SEISMIC_BIN="${XDG_CONFIG_HOME:-$HOME}/.seismic/bin"
+          export PATH="$SEISMIC_BIN:$PATH"
+          sfoundryup
+          echo "$SEISMIC_BIN" >> $GITHUB_PATH
       - name: cargo test
         run: cargo test --workspace

--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -58,8 +58,7 @@ jobs:
       # Would be nice also to run the provider integration tests against the latest stable and latest nightly version (sfoundryup -i nightly) of sanvil.
       - name: Install sfoundry (sanvil)
         run: |
-          curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
-          ~/.seismic/bin/sfoundryup
+          curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/foundryup | bash && sfoundryup
           echo "$HOME/.seismic/bin" >> $GITHUB_PATH
       - name: cargo test
         run: cargo test --workspace

--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -54,9 +54,7 @@ pub trait InputDecryptionElements: Clone {
             let ciphertext = tx.get_input()?;
             let decrypted_data = seismic_elements
                 .decrypt(decryption_key, &ciphertext, &tx_metadata)
-                .map_err(|e| {
-                    InputDecryptionElementsError::DecryptionError(e.to_string())
-                })?;
+                .map_err(|e| InputDecryptionElementsError::DecryptionError(e.to_string()))?;
             tx.set_input(Bytes::from(decrypted_data))?;
         }
         Ok(tx)


### PR DESCRIPTION
This is now possible with sfoundryup which downloads pre-built binaries of sanvil instead of building from source like previously, which was why afaiu we needed the self-hosted runner.