### PR TITLE
fix: SeismicTx eip712 serialization not injective

### DIFF
--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -1162,6 +1162,37 @@ mod tests {
         let _signature_hash = decoded.eip712_signature_hash();
     }
 
+    // Verify that Call(Address::ZERO) survives EIP-712 encode/decode round-trip.
+    // We at some point had a bug where this would get serialized to a CREATE tx.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_eip712_call_zero_address_round_trip() {
+        let tx = TxSeismic {
+            chain_id: 1u64,
+            nonce: 42,
+            gas_price: 1_000_000_000,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::from(1u64),
+            seismic_elements: TxSeismicElements {
+                encryption_pubkey: TxSeismicElements::default().encryption_pubkey,
+                encryption_nonce: U96::from(1),
+                message_version: 2,
+                recent_block_hash: B256::ZERO,
+                expires_at_block: 100,
+                signed_read: false,
+            },
+            input: Bytes::default(),
+        };
+
+        let typed_data = tx.eip712_to_type_data();
+        let decoded = TxSeismic::eip712_decode(&typed_data).unwrap();
+
+        assert_eq!(tx.to, TxKind::Call(Address::ZERO));
+        assert_eq!(decoded.to, TxKind::Call(Address::ZERO));
+        assert_eq!(decoded, tx);
+    }
+
     #[test]
     fn test_eip712_hash() {
         let tx = TxSeismic {

--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -465,8 +465,9 @@ impl TxSeismic {
                   { "name": "nonce", "type": "uint64" },
                   { "name": "gasPrice", "type": "uint128" },
                   { "name": "gasLimit", "type": "uint64" },
-                  // if blank, we assume it's a create
+                  // When isCreate=true, to=0x0.
                   { "name": "to", "type": "address" },
+                  { "name": "isCreate", "type": "bool" },
                   { "name": "value", "type": "uint256" },
                   // compressed secp256k1 public key (33 bytes)
                   { "name": "input", "type": "bytes" },
@@ -495,6 +496,7 @@ impl TxSeismic {
                     TxKind::Create => Address::ZERO.to_string(),
                     TxKind::Call(to) => to.to_string(),
                 },
+                "isCreate": self.to.is_create(),
                 "value": self.value.to_string(),
                 "input": self.input.to_string(),
                 "encryptionPubkey": self.seismic_elements.encryption_pubkey.to_string(),
@@ -516,11 +518,22 @@ impl TxSeismic {
         // Extract the `message` field from TypedData (JSON format)
         let message = serde_json::to_value(&typed_data.message)
             .map_err(|_| Eip712Error::DecodeError("Failed to serialize message".to_string()))?;
+
+        // Extract the explicit isCreate flag
+        let is_create = message
+            .get("isCreate")
+            .and_then(|v| v.as_bool())
+            .ok_or_else(|| {
+                Eip712Error::DecodeError("Missing or invalid isCreate field".to_string())
+            })?;
+
         // Deserialize JSON `message` into `TxSeismic`
         let mut tx: TxSeismic = serde_json::from_value(message)
-            .map_err(|_| Eip712Error::DecodeError("Failed to deserialize message".to_string()))?;
-
-        if tx.to == TxKind::Call(Address::ZERO) {
+        .map_err(|_| Eip712Error::DecodeError("Failed to deserialize message".to_string()))?;
+    
+        // Note: serde deserializes `to: Address::ZERO` as `TxKind::Call(Address::ZERO)`,
+        // so we use the isCreate flag to distinguish Create from Call(Address::ZERO).
+        if is_create {
             tx.to = TxKind::Create;
         }
 

--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -520,17 +520,14 @@ impl TxSeismic {
             .map_err(|_| Eip712Error::DecodeError("Failed to serialize message".to_string()))?;
 
         // Extract the explicit isCreate flag
-        let is_create = message
-            .get("isCreate")
-            .and_then(|v| v.as_bool())
-            .ok_or_else(|| {
-                Eip712Error::DecodeError("Missing or invalid isCreate field".to_string())
-            })?;
+        let is_create = message.get("isCreate").and_then(|v| v.as_bool()).ok_or_else(|| {
+            Eip712Error::DecodeError("Missing or invalid isCreate field".to_string())
+        })?;
 
         // Deserialize JSON `message` into `TxSeismic`
         let mut tx: TxSeismic = serde_json::from_value(message)
-        .map_err(|_| Eip712Error::DecodeError("Failed to deserialize message".to_string()))?;
-    
+            .map_err(|_| Eip712Error::DecodeError("Failed to deserialize message".to_string()))?;
+
         // Note: serde deserializes `to: Address::ZERO` as `TxKind::Call(Address::ZERO)`,
         // so we use the isCreate flag to distinguish Create from Call(Address::ZERO).
         if is_create {


### PR DESCRIPTION
Fixes veridise-875.

EIP-712 encoding for TxSeismic represented both TxKind::Create and TxKind::Call(Address::ZERO) as the zero address in the `to` field. On decode, any zero address was normalized to Create, silently changing the transaction intent for calls to the zero address.

Fix: add an explicit `bool isCreate` field to the EIP-712 TxSeismic type schema, placed after `to`. Encoding sets it from TxKind::is_create(), decoding uses it instead of comparing to == Address::ZERO.

## Downtrean Impact

This changes the EIP-712 type hash, so all signing hashes change.                                                                                                           
RLP encoding and tx hashes are unaffected.                                                                                                                                  

## TODO next steps

Clients must be updated:
- TypeScript (seismic-viem): signSeismicTypedData.ts and chain.ts updated but not yet tested                                                                                                                                                
- Python (seismic_web3): eip712.py updated but hardcoded expected hash values in tests/test_eip712.py need recomputing  (struct_hash, signing_hash, signed tx cross-validation vectors)