### PR TITLE
fix: panic on unknown/invalid tx variants

### DIFF
--- a/crates/network/src/foundry/envelope.rs
+++ b/crates/network/src/foundry/envelope.rs
@@ -105,10 +105,9 @@ impl TryFrom<SeismicFoundryTxEnvelope> for AnyTxEnvelope {
         match value {
             SeismicFoundryTxEnvelope::Ethereum(tx) => Ok(AnyTxEnvelope::Ethereum(tx)),
             SeismicFoundryTxEnvelope::Unknown(tx) => Ok(AnyTxEnvelope::Unknown(tx)),
-            v @ SeismicFoundryTxEnvelope::Seismic(_) => Err(ValueError::new_static(
-                v,
-                "Can't convert Seismic transaction to AnyTxEnvelope",
-            )),
+            v @ SeismicFoundryTxEnvelope::Seismic(_) => {
+                Err(ValueError::new_static(v, "Can't convert Seismic transaction to AnyTxEnvelope"))
+            }
         }
     }
 }

--- a/crates/network/src/foundry/envelope.rs
+++ b/crates/network/src/foundry/envelope.rs
@@ -29,19 +29,26 @@ pub enum SeismicFoundryTxEnvelope {
 }
 
 impl SeismicFoundryTxEnvelope {
-    /// Convert to AnyTxEnvelope
-    pub fn to_any_tx_envelope(&self) -> AnyTxEnvelope {
+    /// Convert to AnyTxEnvelope.
+    ///
+    /// Returns an error for Seismic transactions, which have no AnyTxEnvelope
+    /// representation.
+    pub fn to_any_tx_envelope(&self) -> Result<AnyTxEnvelope, ValueError<&Self>> {
         match self {
-            SeismicFoundryTxEnvelope::Ethereum(tx) => AnyTxEnvelope::Ethereum(tx.clone()),
-            SeismicFoundryTxEnvelope::Unknown(tx) => AnyTxEnvelope::Unknown(tx.clone()),
-            SeismicFoundryTxEnvelope::Seismic(_) => {
-                panic!("Can't convert Seismic transaction to AnyTxEnvelope")
-            }
+            SeismicFoundryTxEnvelope::Ethereum(tx) => Ok(AnyTxEnvelope::Ethereum(tx.clone())),
+            SeismicFoundryTxEnvelope::Unknown(tx) => Ok(AnyTxEnvelope::Unknown(tx.clone())),
+            SeismicFoundryTxEnvelope::Seismic(_) => Err(ValueError::new_static(
+                self,
+                "Can't convert Seismic transaction to AnyTxEnvelope",
+            )),
         }
     }
 
-    /// Set the input of the transaction
-    pub fn set_input(&mut self, input: Bytes) {
+    /// Set the input of the transaction.
+    ///
+    /// Returns an error for unknown transaction types whose inner format is
+    /// opaque.
+    pub fn set_input(&mut self, input: Bytes) -> Result<(), &'static str> {
         match self {
             SeismicFoundryTxEnvelope::Seismic(tx) => {
                 let tx = tx.tx_mut();
@@ -70,9 +77,10 @@ impl SeismicFoundryTxEnvelope {
                 }
             },
             SeismicFoundryTxEnvelope::Unknown(_) => {
-                unimplemented!("Can't set input for unknown transaction");
+                return Err("Can't set input for unknown transaction");
             }
         }
+        Ok(())
     }
 
     /// Returns true if this is the ethereum transaction variant
@@ -90,9 +98,18 @@ impl SeismicFoundryTxEnvelope {
     }
 }
 
-impl From<SeismicFoundryTxEnvelope> for AnyTxEnvelope {
-    fn from(value: SeismicFoundryTxEnvelope) -> Self {
-        value.to_any_tx_envelope()
+impl TryFrom<SeismicFoundryTxEnvelope> for AnyTxEnvelope {
+    type Error = ValueError<SeismicFoundryTxEnvelope>;
+
+    fn try_from(value: SeismicFoundryTxEnvelope) -> Result<Self, Self::Error> {
+        match value {
+            SeismicFoundryTxEnvelope::Ethereum(tx) => Ok(AnyTxEnvelope::Ethereum(tx)),
+            SeismicFoundryTxEnvelope::Unknown(tx) => Ok(AnyTxEnvelope::Unknown(tx)),
+            v @ SeismicFoundryTxEnvelope::Seismic(_) => Err(ValueError::new_static(
+                v,
+                "Can't convert Seismic transaction to AnyTxEnvelope",
+            )),
+        }
     }
 }
 
@@ -101,7 +118,8 @@ impl Typed2718 for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.ty()
         } else {
-            self.to_any_tx_envelope().ty()
+            // SAFETY: Seismic variant handled above; Ethereum/Unknown always succeed
+            self.to_any_tx_envelope().expect("non-Seismic variant").ty()
         }
     }
 }
@@ -111,14 +129,14 @@ impl Encodable2718 for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.encode_2718(out);
         } else {
-            self.to_any_tx_envelope().encode_2718(out);
+            self.to_any_tx_envelope().expect("non-Seismic variant").encode_2718(out);
         }
     }
     fn encode_2718_len(&self) -> usize {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.encode_2718_len()
         } else {
-            self.to_any_tx_envelope().encode_2718_len()
+            self.to_any_tx_envelope().expect("non-Seismic variant").encode_2718_len()
         }
     }
 
@@ -126,7 +144,7 @@ impl Encodable2718 for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.trie_hash()
         } else {
-            self.to_any_tx_envelope().trie_hash()
+            self.to_any_tx_envelope().expect("non-Seismic variant").trie_hash()
         }
     }
 }
@@ -155,7 +173,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().chain_id()
         } else {
-            self.to_any_tx_envelope().chain_id()
+            self.to_any_tx_envelope().expect("non-Seismic variant").chain_id()
         }
     }
 
@@ -163,7 +181,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().nonce()
         } else {
-            self.to_any_tx_envelope().nonce()
+            self.to_any_tx_envelope().expect("non-Seismic variant").nonce()
         }
     }
 
@@ -171,7 +189,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().gas_limit()
         } else {
-            self.to_any_tx_envelope().gas_limit()
+            self.to_any_tx_envelope().expect("non-Seismic variant").gas_limit()
         }
     }
 
@@ -180,7 +198,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().gas_price()
         } else {
-            self.to_any_tx_envelope().gas_price()
+            self.to_any_tx_envelope().expect("non-Seismic variant").gas_price()
         }
     }
 
@@ -188,7 +206,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().max_fee_per_gas()
         } else {
-            self.to_any_tx_envelope().max_fee_per_gas()
+            self.to_any_tx_envelope().expect("non-Seismic variant").max_fee_per_gas()
         }
     }
 
@@ -196,7 +214,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().max_priority_fee_per_gas()
         } else {
-            self.to_any_tx_envelope().max_priority_fee_per_gas()
+            self.to_any_tx_envelope().expect("non-Seismic variant").max_priority_fee_per_gas()
         }
     }
 
@@ -204,7 +222,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().max_fee_per_blob_gas()
         } else {
-            self.to_any_tx_envelope().max_fee_per_blob_gas()
+            self.to_any_tx_envelope().expect("non-Seismic variant").max_fee_per_blob_gas()
         }
     }
 
@@ -212,7 +230,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().priority_fee_or_price()
         } else {
-            self.to_any_tx_envelope().priority_fee_or_price()
+            self.to_any_tx_envelope().expect("non-Seismic variant").priority_fee_or_price()
         }
     }
 
@@ -220,7 +238,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().effective_gas_price(base_fee)
         } else {
-            self.to_any_tx_envelope().effective_gas_price(base_fee)
+            self.to_any_tx_envelope().expect("non-Seismic variant").effective_gas_price(base_fee)
         }
     }
 
@@ -228,7 +246,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().effective_tip_per_gas(base_fee)
         } else {
-            self.to_any_tx_envelope().effective_tip_per_gas(base_fee)
+            self.to_any_tx_envelope().expect("non-Seismic variant").effective_tip_per_gas(base_fee)
         }
     }
 
@@ -236,7 +254,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().is_dynamic_fee()
         } else {
-            self.to_any_tx_envelope().is_dynamic_fee()
+            self.to_any_tx_envelope().expect("non-Seismic variant").is_dynamic_fee()
         }
     }
 
@@ -244,7 +262,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().kind()
         } else {
-            self.to_any_tx_envelope().kind()
+            self.to_any_tx_envelope().expect("non-Seismic variant").kind()
         }
     }
 
@@ -252,7 +270,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().is_create()
         } else {
-            self.to_any_tx_envelope().is_create()
+            self.to_any_tx_envelope().expect("non-Seismic variant").is_create()
         }
     }
 
@@ -260,7 +278,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().to()
         } else {
-            self.to_any_tx_envelope().to()
+            self.to_any_tx_envelope().expect("non-Seismic variant").to()
         }
     }
 
@@ -268,7 +286,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().value()
         } else {
-            self.to_any_tx_envelope().value()
+            self.to_any_tx_envelope().expect("non-Seismic variant").value()
         }
     }
 
@@ -308,7 +326,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().blob_count()
         } else {
-            self.to_any_tx_envelope().blob_count()
+            self.to_any_tx_envelope().expect("non-Seismic variant").blob_count()
         }
     }
 
@@ -317,7 +335,7 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().blob_gas_used()
         } else {
-            self.to_any_tx_envelope().blob_gas_used()
+            self.to_any_tx_envelope().expect("non-Seismic variant").blob_gas_used()
         }
     }
 
@@ -333,12 +351,12 @@ impl TransactionTrait for SeismicFoundryTxEnvelope {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = self {
             tx.tx().authorization_count()
         } else {
-            self.to_any_tx_envelope().authorization_count()
+            self.to_any_tx_envelope().expect("non-Seismic variant").authorization_count()
         }
     }
 }
 
-impl<Eip4844> From<SeismicFoundryTxEnvelope> for SeismicTxEnvelope<Eip4844>
+impl<Eip4844> TryFrom<SeismicFoundryTxEnvelope> for SeismicTxEnvelope<Eip4844>
 where
     Eip4844: RlpEcdsaEncodableTx
         + RlpEcdsaDecodableTx
@@ -348,19 +366,24 @@ where
         + SignableTransaction<Signature>,
     TxEip4844Variant: Into<Eip4844>,
 {
-    fn from(foundry_tx: SeismicFoundryTxEnvelope) -> Self {
+    type Error = ValueError<SeismicFoundryTxEnvelope>;
+
+    fn try_from(foundry_tx: SeismicFoundryTxEnvelope) -> Result<Self, Self::Error> {
         match foundry_tx {
-            SeismicFoundryTxEnvelope::Seismic(tx) => SeismicTxEnvelope::Seismic(tx),
+            SeismicFoundryTxEnvelope::Seismic(tx) => Ok(SeismicTxEnvelope::Seismic(tx)),
             SeismicFoundryTxEnvelope::Ethereum(tx_envelope) => match tx_envelope {
-                EthereumTxEnvelope::Eip1559(tx) => SeismicTxEnvelope::Eip1559(tx),
-                EthereumTxEnvelope::Eip2930(tx) => SeismicTxEnvelope::Eip2930(tx),
+                EthereumTxEnvelope::Eip1559(tx) => Ok(SeismicTxEnvelope::Eip1559(tx)),
+                EthereumTxEnvelope::Eip2930(tx) => Ok(SeismicTxEnvelope::Eip2930(tx)),
                 EthereumTxEnvelope::Eip4844(tx) => {
-                    SeismicTxEnvelope::Eip4844(tx.map(|inner_tx| inner_tx.into()))
+                    Ok(SeismicTxEnvelope::Eip4844(tx.map(|inner_tx| inner_tx.into())))
                 }
-                EthereumTxEnvelope::Eip7702(tx) => SeismicTxEnvelope::Eip7702(tx),
-                EthereumTxEnvelope::Legacy(tx) => SeismicTxEnvelope::Legacy(tx),
+                EthereumTxEnvelope::Eip7702(tx) => Ok(SeismicTxEnvelope::Eip7702(tx)),
+                EthereumTxEnvelope::Legacy(tx) => Ok(SeismicTxEnvelope::Legacy(tx)),
             },
-            SeismicFoundryTxEnvelope::Unknown(_) => unimplemented!(),
+            v @ SeismicFoundryTxEnvelope::Unknown(_) => Err(ValueError::new_static(
+                v,
+                "Can't convert unknown transaction to SeismicTxEnvelope",
+            )),
         }
     }
 }

--- a/crates/network/src/foundry/mod.rs
+++ b/crates/network/src/foundry/mod.rs
@@ -337,7 +337,9 @@ impl NetworkWallet<SeismicFoundry> for EthereumWallet {
                 }
                 .into()
             }
-            SeismicFoundryTypedTransaction::Unknown(_) => unreachable!(),
+            SeismicFoundryTypedTransaction::Unknown(_) => {
+                return Err(alloy_signer::Error::other("Cannot sign unknown transaction type"));
+            }
         };
         Ok(signed_envelope)
     }

--- a/crates/network/src/foundry/tx_request.rs
+++ b/crates/network/src/foundry/tx_request.rs
@@ -181,9 +181,12 @@ impl From<SeismicFoundryTypedTransaction> for SeismicFoundryTransactionRequest {
                 EthereumTypedTransaction::Eip2930(tx) => WithOtherFields::new(tx.into()),
                 EthereumTypedTransaction::Legacy(tx) => WithOtherFields::new(tx.into()),
             },
-            SeismicFoundryTypedTransaction::Unknown(_) => {
-                unimplemented!("Unknown typed transaction")
-            }
+            // Required by alloy Network trait bounds; Unknown variants should be
+            // filtered before reaching this conversion.
+            SeismicFoundryTypedTransaction::Unknown(ref tx) => unreachable!(
+                "Unknown typed transaction (type={}) should not reach request conversion",
+                tx.ty()
+            ),
             SeismicFoundryTypedTransaction::Seismic(tx) => WithOtherFields::new(tx.into()),
         }
     }
@@ -193,7 +196,12 @@ impl From<SeismicFoundryTxEnvelope> for SeismicFoundryTransactionRequest {
     fn from(value: SeismicFoundryTxEnvelope) -> Self {
         match value {
             SeismicFoundryTxEnvelope::Ethereum(tx) => WithOtherFields::new(tx.into()),
-            SeismicFoundryTxEnvelope::Unknown(_) => unimplemented!("Unknown tx envelope"),
+            // Required by alloy Network trait bounds; Unknown variants should be
+            // filtered before reaching this conversion.
+            SeismicFoundryTxEnvelope::Unknown(ref tx) => unreachable!(
+                "Unknown tx envelope (type={}) should not reach request conversion",
+                tx.ty()
+            ),
             SeismicFoundryTxEnvelope::Seismic(tx) => WithOtherFields::new(tx.into()),
         }
     }

--- a/crates/network/src/foundry/typed_tx.rs
+++ b/crates/network/src/foundry/typed_tx.rs
@@ -22,7 +22,8 @@ impl From<SeismicFoundryTxEnvelope> for SeismicFoundryTypedTransaction {
         if let SeismicFoundryTxEnvelope::Seismic(tx) = envelope {
             Self::Seismic(tx.strip_signature())
         } else {
-            let any_typed: AnyTypedTransaction = envelope.to_any_tx_envelope().into();
+            let any_typed: AnyTypedTransaction =
+                envelope.to_any_tx_envelope().expect("non-Seismic variant").into();
             match any_typed {
                 AnyTypedTransaction::Ethereum(tx) => Self::Ethereum(tx),
                 AnyTypedTransaction::Unknown(tx) => Self::Unknown(tx),

--- a/crates/network/src/seismic_network.rs
+++ b/crates/network/src/seismic_network.rs
@@ -196,7 +196,7 @@ impl SeismicNetwork for SeismicFoundry {
                 Ok(Self::TxEnvelope::Ethereum(EthereumTxEnvelope::from(signed)))
             }
             Self::UnsignedTx::Unknown(_) => {
-                unimplemented!("Cannot sign unknown transaction type");
+                return Err(alloy_signer::Error::other("Cannot sign unknown transaction type"));
             }
             Self::UnsignedTx::Seismic(mut t) => {
                 let sig = wallet.sign_transaction_inner(sender, &mut t).await?;

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -187,12 +187,13 @@ impl SeismicTransactionRequest {
 
     /// Builds [`SeismicTypedTransaction`] from this builder. See
     /// [`TransactionRequest::build_typed_tx`] for more info.
-    ///
-    /// Note that EIP-4844 transactions are not supported by Seismic and will be converted into
-    /// EIP-1559 transactions.
     pub fn build_typed_tx(self) -> Result<SeismicTypedTransaction, Self> {
         if self.seismic_elements.is_some() {
-            let tx = self.build_seismic().expect("Failed to build seismic transaction.");
+            let fallback = self.clone();
+            let tx = self.build_seismic().map_err(|e| {
+                eprintln!("Failed to build seismic transaction: {e}");
+                fallback
+            })?;
             return Ok(SeismicTypedTransaction::Seismic(tx));
         }
 


### PR DESCRIPTION
Fixes veridise-907.

Audit finding: multiple transaction conversion and signing paths used panic!, unimplemented!, or unreachable! when encountering unknown or unsupported transaction variants. These are reachable from entry points that accept external requests (e.g. send_transaction, EIP-712 decode), so a crafted transaction could crash the process.

Changes by category:
- Functions already returning Result — return Err instead of panicking:
  - foundry/mod.rs sign_transaction_from: unreachable!() → Err
  - seismic_network.rs sign_transaction_from: unimplemented!() → Err
- Infallible conversions made fallible:
  - envelope.rs to_any_tx_envelope: panic! → returns Result
  - envelope.rs set_input: unimplemented! → returns Result
  - From<SeismicFoundryTxEnvelope> for AnyTxEnvelope → TryFrom
  - From<SeismicFoundryTxEnvelope> for SeismicTxEnvelope → TryFrom
- Expect replaced with proper error propagation:
  - request.rs build_typed_tx: .expect() → .map_err() with eprintln
- Kept as From (required by alloy Network trait bounds) but improved:
  - tx_request.rs From impls: unimplemented!() → unreachable!() with descriptive message including the transaction type byte

The Transaction trait impl methods on SeismicFoundryTxEnvelope still use .expect() on to_any_tx_envelope() in the else branch, but these are provably unreachable — the Seismic variant is always handled by the if-let guard before the else branch executes.

## Future Cleanup

I really don't like the code added here to fix this issue, but I think a proper cleanup would require changing our EnvelopeTypes, which are overlapping right now: the root cause is SeismicFoundryTxEnvelope having three flat variants (Ethereum, Unknown, Seismic) which forces lossy conversions to AnyTxEnvelope. Refactoring to Known(SeismicTxEnvelope) | Unknown would eliminate to_any_tx_envelope entirely and remove all the expect calls in the Transaction trait impl.

Here's another similar plan I've been thinking of letting Claude rip through:
```
TxSeismic is a known, typed transaction — it conceptually belongs in the typed enum (SeismicTxEnvelope), which is where it already is. The Foundry   
  "any" envelope should just wrap that.
                                                                                                                                                                             
  The clean design would be:
                                                                                                                                                                             
  // Instead of current:
  enum SeismicFoundryTxEnvelope {                                                                                                                                            
      Ethereum(TxEnvelope),        // 5 EIP types
      Unknown(UnknownTxEnvelope),                                                                                                                                            
      Seismic(Signed<TxSeismic>),  // duplicated!                                                                                                                            
  }
                                                                                                                                                                             
  // It could be: 
  enum SeismicFoundryTxEnvelope {
      Known(SeismicTxEnvelope),    // all 6 typed variants including Seismic                                                                                                 
      Unknown(UnknownTxEnvelope),
  }                                                                                                                                                                          
                  
  This eliminates the duplication and keeps Seismic only in the typed layer where it belongs.                                                                                
                  
  Why it wasn't done that way: The diff-minimization strategy from the CLAUDE.md. Upstream Foundry has AnyTxEnvelope { Ethereum(TxEnvelope), Unknown(...) }. The Seismic fork
   kept that structure intact and just bolted on a third Seismic variant — minimal diff, easy to merge upstream changes. Refactoring to wrap SeismicTxEnvelope instead of
  TxEnvelope would touch more code and create merge conflicts.                                                                                                               
                  
  Can they be collapsed? Yes, it's a valid refactor. The Known(SeismicTxEnvelope) approach would mean every match on SeismicFoundryTxEnvelope that currently has separate    
  Ethereum/Seismic arms would become Known(inner) with a nested match, so it's a nontrivial diff — but architecturally cleaner.
```