### PR TITLE
fix: update broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Seismic-Alloy provides the transaction types, network abstractions, and provider
 
 Seismic Foundry includes `sanvil` (Seismic Anvil), which is required for the test suite.
 
-For installation instructions, see the [Seismic documentation](https://docs.seismic.systems/getting-started/publish-your-docs#install-the-local-development-suite).
+For installation instructions, see the [Seismic documentation](https://docs.seismic.systems/getting-started/installation#install-the-local-development-suite).
 
 ## Running Tests
 
-**Before running tests**: Install Seismic Anvil (`sanvil`) to run the full test suite. See installation instructions for [sfoundryup](https://docs.seismic.systems/getting-started/publish-your-docs#install-the-local-development-suite).
+**Before running tests**: Install Seismic Anvil (`sanvil`) to run the full test suite. See installation instructions for [sfoundryup](https://docs.seismic.systems/getting-started/installation#install-the-local-development-suite).
 
 Run the full test suite:
 


### PR DESCRIPTION
The README links to `getting-started/publish-your-docs` which no longer exists on the mdBook site. Updated both links to point to `getting-started/installation` instead.

Closes #72