### PR TITLE
refactor!: clean up InputDecryptionElements trait

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,7 +1,7 @@
 //! Transaction envelope types and utilities
 use crate::{
-    InputDecryptionElements, SeismicTxType, SeismicTypedTransaction,
-    TxSeismic, TxSeismicElements, TxSeismicMetadata,
+    InputDecryptionElements, SeismicTxType, SeismicTypedTransaction, TxSeismic, TxSeismicElements,
+    TxSeismicMetadata,
 };
 use alloy_consensus::{
     transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx},

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -1,6 +1,6 @@
 //! Transaction envelope types and utilities
 use crate::{
-    InputDecryptionElements, InputDecryptionElementsError, SeismicTxType, SeismicTypedTransaction,
+    InputDecryptionElements, SeismicTxType, SeismicTypedTransaction,
     TxSeismic, TxSeismicElements, TxSeismicMetadata,
 };
 use alloy_consensus::{
@@ -409,70 +409,28 @@ impl Transaction for SeismicTxEnvelope {
 }
 
 impl InputDecryptionElements for SeismicTxEnvelope {
-    fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError> {
+    fn seismic_elements(&self) -> Option<TxSeismicElements> {
         match self {
-            Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Legacy".to_string(),
-            )),
-            Self::Eip2930(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip2930".to_string(),
-            )),
-            Self::Eip1559(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip1559".to_string(),
-            )),
-            Self::Eip4844(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip4844".to_string(),
-            )),
-            Self::Eip7702(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip7702".to_string(),
-            )),
-            Self::Seismic(tx) => Ok(tx.tx().get_decryption_elements().unwrap()),
+            Self::Seismic(tx) => tx.tx().seismic_elements(),
+            _ => None,
         }
     }
 
-    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
-        Ok(self.input().clone())
-    }
-
-    fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError> {
+    fn set_input(&mut self, data: Bytes) {
         match self {
-            Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Legacy".to_string(),
-            )),
-            Self::Eip2930(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip2930".to_string(),
-            )),
-            Self::Eip1559(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip1559".to_string(),
-            )),
-            Self::Eip4844(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip4844".to_string(),
-            )),
-            Self::Eip7702(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip7702".to_string(),
-            )),
+            Self::Legacy(tx) => tx.tx_mut().input = data,
+            Self::Eip2930(tx) => tx.tx_mut().input = data,
+            Self::Eip1559(tx) => tx.tx_mut().input = data,
+            Self::Eip4844(tx) => tx.tx_mut().input = data,
+            Self::Eip7702(tx) => tx.tx_mut().input = data,
             Self::Seismic(tx) => tx.tx_mut().set_input(data),
         }
     }
 
-    fn metadata(&self, sender: Address) -> Result<TxSeismicMetadata, InputDecryptionElementsError> {
+    fn metadata(&self, sender: Address) -> Option<TxSeismicMetadata> {
         match self {
-            Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Legacy".to_string(),
-            )),
-            Self::Eip2930(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip2930".to_string(),
-            )),
-            Self::Eip1559(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip1559".to_string(),
-            )),
-            Self::Eip4844(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip4844".to_string(),
-            )),
-            Self::Eip7702(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTxEnvelope::Eip7702".to_string(),
-            )),
-            Self::Seismic(tx) => Ok(tx.tx().tx_metadata(sender)),
+            Self::Seismic(tx) => Some(tx.tx().tx_metadata(sender)),
+            _ => None,
         }
     }
 }

--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -26,29 +26,31 @@ use crate::transaction::eip712::{Eip712Error, Eip712Result, TypedDataRequest};
 #[cfg(feature = "serde")]
 use crate::transaction::tx_serde::pubkey_with_prefix_deserialize;
 
-/// An extension of the [`Transaction`] trait for Seismic's decryptable transactions.
-pub trait InputDecryptionElements: Clone {
-    /// Returns the elements necessary to decrypt the 'input' field of the transaction.
-    /// May return `None` if the Seismic tx type does not support decryption.
-    fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError>;
+/// An extension of the [`Transaction`] trait for transactions that may be Seismic
+/// and support input decryption.
+pub trait InputDecryptionElements: Transaction + Clone {
+    /// Returns the seismic elements if this is a Seismic transaction, `None` otherwise.
+    fn seismic_elements(&self) -> Option<TxSeismicElements>;
 
-    /// Returns the 'input' field of the transaction.
-    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError>;
+    /// Returns tx metadata for encryption with AEAD.
+    /// Returns `None` for non-Seismic transaction types.
+    fn metadata(&self, sender: Address) -> Option<TxSeismicMetadata>;
 
     /// Sets the 'input' field of the transaction to the provided data.
-    fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError>;
-
-    /// Returns tx metadata for encryption with AEAD
-    fn metadata(&self, sender: Address) -> Result<TxSeismicMetadata, InputDecryptionElementsError>;
+    /// Only exists so `decrypt_input` can work as a default method.
+    fn set_input(&mut self, data: Bytes);
 
     /// Validate block-related security features (expiration and recent block hash).
     /// Non-Seismic transaction types are passed through without validation.
+    //
+    // TODO(samlaf): This doesn't need to be on the trait — it only uses `seismic_elements()` and
+    // could be a free function taking `Option<TxSeismicElements>` instead.
     fn validate_block(
         &self,
         current_block: u64,
         recent_blocks: &[B256],
     ) -> Result<(), SeismicValidationError> {
-        if let Ok(elements) = self.get_decryption_elements() {
+        if let Some(elements) = self.seismic_elements() {
             if current_block > elements.expires_at_block {
                 return Err(SeismicValidationError::TransactionExpired {
                     current_block,
@@ -65,41 +67,31 @@ pub trait InputDecryptionElements: Clone {
     }
 
     /// Creates a copy of the transaction with the input field set to the plaintext.
-    /// Errors if the decryption fails, etc.
-    fn plaintext_copy(
+    /// Returns the original transaction unchanged if it's not a Seismic transaction.
+    fn decrypt_input(
         &self,
         decryption_key: &SecretKey,
         sender: Address,
-    ) -> Result<Self, InputDecryptionElementsError> {
+    ) -> Result<Self, DecryptionError> {
         let mut tx = self.clone();
-        if let Ok(seismic_elements) = tx.get_decryption_elements() {
-            let tx_metadata = self.metadata(sender)?;
-            let ciphertext = tx.get_input()?;
+        if let Some(seismic_elements) = tx.seismic_elements() {
+            let tx_metadata = self
+                .metadata(sender)
+                .expect("seismic_elements() returned Some but metadata() returned None");
+            let ciphertext = Transaction::input(&tx).clone();
             let decrypted_data = seismic_elements
                 .decrypt(decryption_key, &ciphertext, &tx_metadata)
-                .map_err(|e| InputDecryptionElementsError::DecryptionError(e.to_string()))?;
-            tx.set_input(Bytes::from(decrypted_data))?;
+                .map_err(|e| DecryptionError(e.to_string()))?;
+            tx.set_input(Bytes::from(decrypted_data));
         }
         Ok(tx)
     }
 }
 
-/// Error type for [`InputDecryptionElements`] trait
+/// Error returned by [`InputDecryptionElements::decrypt_input`] when decryption fails.
 #[derive(Debug, Clone, Error)]
-pub enum InputDecryptionElementsError {
-    /// The transaction type does not support decryption.
-    #[error("Unsupported transaction type: {0}")]
-    UnsupportedTxType(String),
-    /// The decryption failed
-    #[error("Decryption failed: {0}")]
-    DecryptionError(String),
-    /// No elements were found
-    #[error("Expected Elements but no elements found")]
-    NoElements,
-    /// A required field is missing
-    #[error("Missing required field: {0}")]
-    MissingField(&'static str),
-}
+#[error("Decryption failed: {0}")]
+pub struct DecryptionError(pub String);
 
 /// Error type for seismic transaction validation
 #[derive(Debug, Clone, Error)]
@@ -126,22 +118,15 @@ impl<T> InputDecryptionElements for WithOtherFields<T>
 where
     T: InputDecryptionElements,
 {
-    fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError> {
-        self.inner.get_decryption_elements()
+    fn seismic_elements(&self) -> Option<TxSeismicElements> {
+        self.inner.seismic_elements()
     }
 
-    fn get_input(&self) -> Result<alloy_primitives::Bytes, InputDecryptionElementsError> {
-        self.inner.get_input()
-    }
-
-    fn set_input(
-        &mut self,
-        data: alloy_primitives::Bytes,
-    ) -> Result<(), InputDecryptionElementsError> {
+    fn set_input(&mut self, data: alloy_primitives::Bytes) {
         self.inner.set_input(data)
     }
 
-    fn metadata(&self, sender: Address) -> Result<TxSeismicMetadata, InputDecryptionElementsError> {
+    fn metadata(&self, sender: Address) -> Option<TxSeismicMetadata> {
         self.inner.metadata(sender)
     }
 }
@@ -844,21 +829,16 @@ impl Transaction for TxSeismic {
 }
 
 impl InputDecryptionElements for TxSeismic {
-    fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError> {
-        Ok(self.seismic_elements)
+    fn seismic_elements(&self) -> Option<TxSeismicElements> {
+        Some(self.seismic_elements)
     }
 
-    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
-        Ok(self.input.clone())
-    }
-
-    fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError> {
+    fn set_input(&mut self, data: Bytes) {
         self.input = data;
-        Ok(())
     }
 
-    fn metadata(&self, sender: Address) -> Result<TxSeismicMetadata, InputDecryptionElementsError> {
-        Ok(self.tx_metadata(sender))
+    fn metadata(&self, sender: Address) -> Option<TxSeismicMetadata> {
+        Some(self.tx_metadata(sender))
     }
 }
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,6 +1,6 @@
 //! Typed transaction types and utilities
 use crate::{
-    InputDecryptionElements, InputDecryptionElementsError, SeismicTxEnvelope, SeismicTxType,
+    InputDecryptionElements, SeismicTxEnvelope, SeismicTxType,
     TxSeismic, TxSeismicElements, TxSeismicMetadata,
 };
 use alloy_consensus::{
@@ -419,70 +419,28 @@ impl Transaction for SeismicTypedTransaction {
 }
 
 impl InputDecryptionElements for SeismicTypedTransaction {
-    fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError> {
+    fn seismic_elements(&self) -> Option<TxSeismicElements> {
         match self {
-            Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Legacy".to_string(),
-            )),
-            Self::Eip1559(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip1559".to_string(),
-            )),
-            Self::Eip2930(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip2930".to_string(),
-            )),
-            Self::Eip4844(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip4844".to_string(),
-            )),
-            Self::Eip7702(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip7702".to_string(),
-            )),
-            Self::Seismic(tx) => tx.get_decryption_elements(),
+            Self::Seismic(tx) => tx.seismic_elements(),
+            _ => None,
         }
     }
 
-    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
-        Ok(self.input().clone())
-    }
-
-    fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError> {
+    fn set_input(&mut self, data: Bytes) {
         match self {
-            Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Legacy".to_string(),
-            )),
-            Self::Eip1559(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip1559".to_string(),
-            )),
-            Self::Eip2930(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip2930".to_string(),
-            )),
-            Self::Eip4844(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip4844".to_string(),
-            )),
-            Self::Eip7702(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip7702".to_string(),
-            )),
+            Self::Legacy(tx) => tx.input = data,
+            Self::Eip2930(tx) => tx.input = data,
+            Self::Eip1559(tx) => tx.input = data,
+            Self::Eip4844(tx) => tx.input = data,
+            Self::Eip7702(tx) => tx.input = data,
             Self::Seismic(tx) => tx.set_input(data),
         }
     }
 
-    fn metadata(&self, sender: Address) -> Result<TxSeismicMetadata, InputDecryptionElementsError> {
+    fn metadata(&self, sender: Address) -> Option<TxSeismicMetadata> {
         match self {
-            Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Legacy".to_string(),
-            )),
-            Self::Eip1559(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip1559".to_string(),
-            )),
-            Self::Eip2930(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip2930".to_string(),
-            )),
-            Self::Eip4844(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip4844".to_string(),
-            )),
-            Self::Eip7702(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
-                "SeismicTypedTransaction::Eip7702".to_string(),
-            )),
-            Self::Seismic(tx) => Ok(tx.tx_metadata(sender)),
+            Self::Seismic(tx) => Some(tx.tx_metadata(sender)),
+            _ => None,
         }
     }
 }

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -1,7 +1,7 @@
 //! Typed transaction types and utilities
 use crate::{
-    InputDecryptionElements, SeismicTxEnvelope, SeismicTxType,
-    TxSeismic, TxSeismicElements, TxSeismicMetadata,
+    InputDecryptionElements, SeismicTxEnvelope, SeismicTxType, TxSeismic, TxSeismicElements,
+    TxSeismicMetadata,
 };
 use alloy_consensus::{
     transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx},

--- a/crates/network/src/fillers.rs
+++ b/crates/network/src/fillers.rs
@@ -14,7 +14,7 @@ use alloy_provider::{
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_transport::{TransportErrorKind, TransportResult};
-use seismic_alloy_consensus::{InputDecryptionElements, TxSeismicElements};
+use seismic_alloy_consensus::TxSeismicElements;
 use seismic_alloy_rpc_types::SeismicTransactionRequest;
 use seismic_enclave::secp256k1::{PublicKey, Secp256k1};
 use std::str::FromStr;
@@ -57,20 +57,19 @@ impl SeismicGasFiller {
     fn is_seismic_tx<N>(&self, tx: &N::TransactionRequest) -> bool
     where
         N: SeismicNetwork,
-        N::TransactionRequest: InputDecryptionElements,
+        N::TransactionRequest: AsRef<SeismicTransactionRequest>,
         <N as Network>::UnsignedTx: Send + Sync,
     {
         // Only treat as seismic if elements are actually set
         // This ensures estimate_gas is called on regular tx during prepare() phase
-        tx.get_decryption_elements().is_ok()
+        tx.as_ref().seismic_elements.is_some()
     }
 }
 
 impl<N: SeismicNetwork> TxFiller<N> for SeismicGasFiller
 where
-    <N as Network>::TransactionRequest: AsRef<SeismicTransactionRequest>
-        + AsMut<SeismicTransactionRequest>
-        + InputDecryptionElements,
+    <N as Network>::TransactionRequest:
+        AsRef<SeismicTransactionRequest> + AsMut<SeismicTransactionRequest>,
     <N as Network>::UnsignedTx: Send + Sync,
 {
     // (Option<GasFillable>, Option<(u128, RpcClient)>)
@@ -250,9 +249,7 @@ impl SeismicElementsFiller {
 
 impl<N: SeismicNetwork> TxFiller<N> for SeismicElementsFiller
 where
-    N::TransactionRequest: AsRef<SeismicTransactionRequest>
-        + AsMut<SeismicTransactionRequest>
-        + InputDecryptionElements,
+    N::TransactionRequest: AsRef<SeismicTransactionRequest> + AsMut<SeismicTransactionRequest>,
     N::UnsignedTx: Send + Sync,
 {
     // Fillable contains: Some((tee_pubkey, provider_secret_key, elements, plaintext)) for fill()
@@ -426,7 +423,8 @@ where
                 )
             })?;
 
-            let metadata = builder.metadata(sender).map_err(|e| {
+            let seismic_req: &SeismicTransactionRequest = builder.as_ref();
+            let metadata = seismic_req.metadata(sender).map_err(|e| {
                 TransportErrorKind::custom_str(&format!("Error creating metadata: {:?}", e))
             })?;
 
@@ -437,8 +435,7 @@ where
                 )?;
 
             // Set encrypted input
-            N::set_request_input(builder, encrypted)
-                .map_err(|_| TransportErrorKind::custom_str("Error setting encrypted input"))?;
+            N::set_request_input(builder, encrypted);
         }
         Ok(tx)
     }

--- a/crates/network/src/foundry/envelope.rs
+++ b/crates/network/src/foundry/envelope.rs
@@ -13,7 +13,7 @@ use alloy_network::{
 use alloy_primitives::{Address, Bytes, ChainId, Selector, Signature, TxKind, B256, U256};
 use alloy_rpc_types_eth::AccessList;
 use seismic_alloy_consensus::{
-    InputDecryptionElements, InputDecryptionElementsError, SeismicTxEnvelope, TxSeismic,
+    InputDecryptionElements, SeismicTxEnvelope, TxSeismic,
 };
 
 /// Seismic Foundry transaction envelope, meant to mimic AnyTxEnvelope
@@ -388,58 +388,40 @@ where
 }
 
 impl InputDecryptionElements for SeismicFoundryTxEnvelope {
-    fn get_decryption_elements(
-        &self,
-    ) -> Result<seismic_alloy_consensus::TxSeismicElements, InputDecryptionElementsError> {
+    fn seismic_elements(&self) -> Option<seismic_alloy_consensus::TxSeismicElements> {
         match self {
-            SeismicFoundryTxEnvelope::Seismic(tx) => tx.tx().get_decryption_elements(),
-            SeismicFoundryTxEnvelope::Ethereum(_) => {
-                Err(InputDecryptionElementsError::UnsupportedTxType("Ethereum".to_string()))
-            }
-            SeismicFoundryTxEnvelope::Unknown(_) => {
-                Err(InputDecryptionElementsError::UnsupportedTxType("Unknown".to_string()))
-            }
+            SeismicFoundryTxEnvelope::Seismic(tx) => tx.tx().seismic_elements(),
+            _ => None,
         }
     }
 
-    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
-        match self {
-            SeismicFoundryTxEnvelope::Seismic(tx) => tx.tx().get_input(),
-            SeismicFoundryTxEnvelope::Ethereum(tx) => Ok(tx.input().clone()),
-            SeismicFoundryTxEnvelope::Unknown(tx) => Ok(tx.input().clone()),
-        }
-    }
-
-    fn set_input(&mut self, data: Bytes) -> Result<(), InputDecryptionElementsError> {
+    fn set_input(&mut self, data: Bytes) {
         match self {
             SeismicFoundryTxEnvelope::Seismic(tx) => tx.tx_mut().set_input(data),
-            SeismicFoundryTxEnvelope::Ethereum(tx) => {
-                match tx {
-                    EthereumTxEnvelope::Eip1559(tx) => {
-                        tx.tx_mut().input = data;
-                    }
-                    EthereumTxEnvelope::Eip2930(tx) => {
-                        tx.tx_mut().input = data;
-                    }
-                    EthereumTxEnvelope::Eip4844(tx) => match tx.tx_mut() {
-                        TxEip4844Variant::TxEip4844(tx) => {
-                            tx.input = data;
-                        }
-                        TxEip4844Variant::TxEip4844WithSidecar(tx) => {
-                            tx.tx.input = data;
-                        }
-                    },
-                    EthereumTxEnvelope::Eip7702(tx) => {
-                        tx.tx_mut().input = data;
-                    }
-                    EthereumTxEnvelope::Legacy(tx) => {
-                        tx.tx_mut().input = data;
-                    }
+            SeismicFoundryTxEnvelope::Ethereum(tx) => match tx {
+                EthereumTxEnvelope::Eip1559(tx) => {
+                    tx.tx_mut().input = data;
                 }
-                Ok(())
-            }
+                EthereumTxEnvelope::Eip2930(tx) => {
+                    tx.tx_mut().input = data;
+                }
+                EthereumTxEnvelope::Eip4844(tx) => match tx.tx_mut() {
+                    TxEip4844Variant::TxEip4844(tx) => {
+                        tx.input = data;
+                    }
+                    TxEip4844Variant::TxEip4844WithSidecar(tx) => {
+                        tx.tx.input = data;
+                    }
+                },
+                EthereumTxEnvelope::Eip7702(tx) => {
+                    tx.tx_mut().input = data;
+                }
+                EthereumTxEnvelope::Legacy(tx) => {
+                    tx.tx_mut().input = data;
+                }
+            },
             SeismicFoundryTxEnvelope::Unknown(_) => {
-                Err(InputDecryptionElementsError::UnsupportedTxType("Unknown".to_string()))
+                unreachable!("set_input called on Unknown tx variant")
             }
         }
     }
@@ -447,15 +429,10 @@ impl InputDecryptionElements for SeismicFoundryTxEnvelope {
     fn metadata(
         &self,
         sender: Address,
-    ) -> Result<seismic_alloy_consensus::TxSeismicMetadata, InputDecryptionElementsError> {
+    ) -> Option<seismic_alloy_consensus::TxSeismicMetadata> {
         match self {
-            SeismicFoundryTxEnvelope::Seismic(tx) => Ok(tx.tx().tx_metadata(sender)),
-            SeismicFoundryTxEnvelope::Ethereum(_) => {
-                Err(InputDecryptionElementsError::UnsupportedTxType("Ethereum".to_string()))
-            }
-            SeismicFoundryTxEnvelope::Unknown(_) => {
-                Err(InputDecryptionElementsError::UnsupportedTxType("Unknown".to_string()))
-            }
+            SeismicFoundryTxEnvelope::Seismic(tx) => Some(tx.tx().tx_metadata(sender)),
+            _ => None,
         }
     }
 }

--- a/crates/network/src/foundry/envelope.rs
+++ b/crates/network/src/foundry/envelope.rs
@@ -12,9 +12,7 @@ use alloy_network::{
 };
 use alloy_primitives::{Address, Bytes, ChainId, Selector, Signature, TxKind, B256, U256};
 use alloy_rpc_types_eth::AccessList;
-use seismic_alloy_consensus::{
-    InputDecryptionElements, SeismicTxEnvelope, TxSeismic,
-};
+use seismic_alloy_consensus::{InputDecryptionElements, SeismicTxEnvelope, TxSeismic};
 
 /// Seismic Foundry transaction envelope, meant to mimic AnyTxEnvelope
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -426,10 +424,7 @@ impl InputDecryptionElements for SeismicFoundryTxEnvelope {
         }
     }
 
-    fn metadata(
-        &self,
-        sender: Address,
-    ) -> Option<seismic_alloy_consensus::TxSeismicMetadata> {
+    fn metadata(&self, sender: Address) -> Option<seismic_alloy_consensus::TxSeismicMetadata> {
         match self {
             SeismicFoundryTxEnvelope::Seismic(tx) => Some(tx.tx().tx_metadata(sender)),
             _ => None,

--- a/crates/network/src/seismic_network.rs
+++ b/crates/network/src/seismic_network.rs
@@ -6,8 +6,7 @@ use alloy_primitives::{Address, Bytes};
 use alloy_provider::fillers::RecommendedFillers;
 use alloy_rpc_types_eth::TransactionInput;
 use seismic_alloy_consensus::{
-    InputDecryptionElements, InputDecryptionElementsError, TxSeismicElements, TypedDataRequest,
-    SEISMIC_TX_TYPE_ID,
+    InputDecryptionElements, TxSeismicElements, TypedDataRequest, SEISMIC_TX_TYPE_ID,
 };
 
 /// A trait for networks that support seismic elements.
@@ -27,16 +26,10 @@ where
     fn get_request_input(req: &Self::TransactionRequest) -> Option<&Bytes>;
     /// Get the envelope input from the transaction envelope.
     fn get_envelope_input(req: &Self::TxEnvelope) -> &Bytes;
-    /// Set the input in the transaction envelope.
-    fn set_request_input(
-        req: &mut Self::TransactionRequest,
-        input: Bytes,
-    ) -> Result<(), InputDecryptionElementsError>;
     /// Set the input in the transaction request.
-    fn set_envelope_input(
-        req: &mut Self::TxEnvelope,
-        input: Bytes,
-    ) -> Result<(), InputDecryptionElementsError>;
+    fn set_request_input(req: &mut Self::TransactionRequest, input: Bytes);
+    /// Set the input in the transaction envelope.
+    fn set_envelope_input(req: &mut Self::TxEnvelope, input: Bytes);
     /// Sign a transaction from the given sender and transaction.
     async fn sign_transaction_from(
         wallet: &SeismicWallet<Self>,
@@ -74,17 +67,10 @@ impl SeismicNetwork for SeismicReth {
     fn get_envelope_input(req: &Self::TxEnvelope) -> &Bytes {
         req.input()
     }
-    fn set_request_input(
-        req: &mut Self::TransactionRequest,
-        input: Bytes,
-    ) -> Result<(), InputDecryptionElementsError> {
+    fn set_request_input(req: &mut Self::TransactionRequest, input: Bytes) {
         req.inner.input = TransactionInput::new(input);
-        Ok(())
     }
-    fn set_envelope_input(
-        req: &mut Self::TxEnvelope,
-        input: Bytes,
-    ) -> Result<(), InputDecryptionElementsError> {
+    fn set_envelope_input(req: &mut Self::TxEnvelope, input: Bytes) {
         req.set_input(input)
     }
     async fn sign_transaction_from(
@@ -187,16 +173,10 @@ impl SeismicNetwork for SeismicFoundry {
     fn get_envelope_input(req: &Self::TxEnvelope) -> &Bytes {
         req.input()
     }
-    fn set_request_input(
-        req: &mut Self::TransactionRequest,
-        input: Bytes,
-    ) -> Result<(), InputDecryptionElementsError> {
-        InputDecryptionElements::set_input(req, input)
+    fn set_request_input(req: &mut Self::TransactionRequest, input: Bytes) {
+        req.inner.input = TransactionInput::new(input);
     }
-    fn set_envelope_input(
-        req: &mut Self::TxEnvelope,
-        input: Bytes,
-    ) -> Result<(), InputDecryptionElementsError> {
+    fn set_envelope_input(req: &mut Self::TxEnvelope, input: Bytes) {
         InputDecryptionElements::set_input(req, input)
     }
     async fn sign_transaction_from(

--- a/crates/prelude/src/foundry.rs
+++ b/crates/prelude/src/foundry.rs
@@ -3,7 +3,7 @@ use alloy_serde::WithOtherFields;
 use seismic_alloy_network::wallet::SeismicWallet;
 
 pub use seismic_alloy_consensus::{
-    Decodable712, Eip712Result, InputDecryptionElements, InputDecryptionElementsError,
+    Decodable712, DecryptionError, Eip712Result, InputDecryptionElements,
     SeismicReceiptEnvelope as AnyReceiptEnvelope, SeismicTxEnvelope as TxEnvelope, TxLegacyFields,
     TxSeismic, TxSeismicElements, TxSeismicMetadata, TypedDataRequest, SEISMIC_TX_TYPE_ID,
 };

--- a/crates/prelude/src/reth.rs
+++ b/crates/prelude/src/reth.rs
@@ -2,7 +2,7 @@
 // TODO: will this be helpful inside reth?
 
 pub use seismic_alloy_consensus::{
-    Decodable712, DecryptionError, Eip712Result, InputDecryptionElements,
-    SeismicReceiptEnvelope, SeismicTxEnvelope, TxLegacyFields, TxSeismic, TxSeismicElements,
-    TxSeismicMetadata, TypedDataRequest, SEISMIC_TX_TYPE_ID,
+    Decodable712, DecryptionError, Eip712Result, InputDecryptionElements, SeismicReceiptEnvelope,
+    SeismicTxEnvelope, TxLegacyFields, TxSeismic, TxSeismicElements, TxSeismicMetadata,
+    TypedDataRequest, SEISMIC_TX_TYPE_ID,
 };

--- a/crates/prelude/src/reth.rs
+++ b/crates/prelude/src/reth.rs
@@ -2,7 +2,7 @@
 // TODO: will this be helpful inside reth?
 
 pub use seismic_alloy_consensus::{
-    Decodable712, Eip712Result, InputDecryptionElements, InputDecryptionElementsError,
+    Decodable712, DecryptionError, Eip712Result, InputDecryptionElements,
     SeismicReceiptEnvelope, SeismicTxEnvelope, TxLegacyFields, TxSeismic, TxSeismicElements,
     TxSeismicMetadata, TypedDataRequest, SEISMIC_TX_TYPE_ID,
 };

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -36,7 +36,6 @@ use alloy_provider::{
 };
 use alloy_rpc_client::RpcClient;
 use alloy_transport::TransportResult;
-use seismic_alloy_consensus::InputDecryptionElements;
 use seismic_alloy_network::{
     fillers::{SeismicElementsFiller, SeismicGasFiller},
     foundry::SeismicFoundry,
@@ -122,8 +121,7 @@ impl SeismicProviderBuilder {
     where
         N::TransactionRequest: AsRef<SeismicTransactionRequest>
             + AsMut<SeismicTransactionRequest>
-            + From<SeismicTransactionRequest>
-            + InputDecryptionElements,
+            + From<SeismicTransactionRequest>,
         N::UnsignedTx: Send + Sync,
         RootProvider<N>: SeismicProviderExt<N>,
     {
@@ -178,8 +176,7 @@ impl<N: SeismicNetwork> SeismicProviderBuilderWithNetwork<N>
 where
     N::TransactionRequest: AsRef<SeismicTransactionRequest>
         + AsMut<SeismicTransactionRequest>
-        + From<SeismicTransactionRequest>
-        + InputDecryptionElements,
+        + From<SeismicTransactionRequest>,
     N::UnsignedTx: Send + Sync,
     RootProvider<N>: SeismicProviderExt<N>,
 {
@@ -226,8 +223,7 @@ impl<N: SeismicNetwork> SeismicProviderBuilderWithWallet<N>
 where
     N::TransactionRequest: AsRef<SeismicTransactionRequest>
         + AsMut<SeismicTransactionRequest>
-        + From<SeismicTransactionRequest>
-        + InputDecryptionElements,
+        + From<SeismicTransactionRequest>,
     N::UnsignedTx: Send + Sync,
     RootProvider<N>: SeismicProviderExt<N>,
 {
@@ -322,8 +318,7 @@ fn build_unsigned_http<N: SeismicNetwork>(url: reqwest::Url) -> SeismicUnsignedP
 where
     N::TransactionRequest: AsRef<SeismicTransactionRequest>
         + AsMut<SeismicTransactionRequest>
-        + From<SeismicTransactionRequest>
-        + InputDecryptionElements,
+        + From<SeismicTransactionRequest>,
     N::UnsignedTx: Send + Sync,
     RootProvider<N>: SeismicProviderExt<N>,
 {
@@ -341,8 +336,7 @@ async fn build_unsigned_ws<N: SeismicNetwork>(
 where
     N::TransactionRequest: AsRef<SeismicTransactionRequest>
         + AsMut<SeismicTransactionRequest>
-        + From<SeismicTransactionRequest>
-        + InputDecryptionElements,
+        + From<SeismicTransactionRequest>,
     N::UnsignedTx: Send + Sync,
     RootProvider<N>: SeismicProviderExt<N>,
 {

--- a/crates/provider/src/decrypt.rs
+++ b/crates/provider/src/decrypt.rs
@@ -11,7 +11,6 @@ use alloy_provider::{
     PendingTransactionBuilder, Provider, ProviderLayer, RootProvider, SendableTx,
 };
 use alloy_transport::TransportResult;
-use seismic_alloy_consensus::InputDecryptionElements;
 
 use crate::SeismicProviderError;
 use seismic_alloy_network::seismic_network::SeismicNetwork;
@@ -135,8 +134,7 @@ where
     N: SeismicNetwork,
     N::TransactionRequest: AsRef<SeismicTransactionRequest>
         + AsMut<SeismicTransactionRequest>
-        + From<SeismicTransactionRequest>
-        + InputDecryptionElements,
+        + From<SeismicTransactionRequest>,
     N::UnsignedTx: Send + Sync,
     F: TxFiller<N>,
     P: Provider<N>,
@@ -164,7 +162,8 @@ where
                         let sender = filled_builder
                             .from()
                             .ok_or_else(|| SeismicProviderError::MissingSender.into_transport())?;
-                        filled_builder.metadata(sender).map_err(|e| {
+                        let seismic_req: &SeismicTransactionRequest = filled_builder.as_ref();
+                        seismic_req.metadata(sender).map_err(|e| {
                             SeismicProviderError::MetadataCreation(format!("{e:?}"))
                                 .into_transport()
                         })?

--- a/crates/rpc-types/src/lib.rs
+++ b/crates/rpc-types/src/lib.rs
@@ -19,7 +19,7 @@ mod request;
 pub use request::*;
 
 mod transaction;
-pub use transaction::SeismicTransactionRequest;
+pub use transaction::{SeismicRequestError, SeismicTransactionRequest};
 
 mod simblock;
 pub use simblock::{SimBlock, SimulatePayload};

--- a/crates/rpc-types/src/transaction.rs
+++ b/crates/rpc-types/src/transaction.rs
@@ -1,4 +1,4 @@
 //! Seismic specific types related to transactions.
 
 mod request;
-pub use request::SeismicTransactionRequest;
+pub use request::{SeismicRequestError, SeismicTransactionRequest};

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -6,14 +6,33 @@ use alloy_consensus::{
 };
 use alloy_eips::{eip7702::SignedAuthorization, Typed2718};
 use alloy_network_primitives::{TransactionBuilder4844, TransactionBuilder7702};
-use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+use alloy_primitives::{Address, Signature, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInput, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use seismic_alloy_consensus::{
-    Decodable712, Eip712Result, InputDecryptionElements, InputDecryptionElementsError,
-    SeismicTxEnvelope, SeismicTxType, SeismicTypedTransaction, TxSeismic, TxSeismicElements,
-    TxSeismicMetadata, TypedDataRequest, SEISMIC_TX_TYPE_ID,
+    Decodable712, Eip712Result, SeismicTxEnvelope, SeismicTxType, SeismicTypedTransaction,
+    TxSeismic, TxSeismicElements, TxSeismicMetadata, TypedDataRequest, SEISMIC_TX_TYPE_ID,
 };
+/// Error type for [`SeismicTransactionRequest`] operations that require builder
+/// fields to be populated (e.g. metadata, decryption).
+#[derive(Debug, Clone)]
+pub enum SeismicRequestError {
+    /// A required builder field is missing.
+    MissingField(&'static str),
+    /// Decryption failed.
+    DecryptionError(String),
+}
+
+impl core::fmt::Display for SeismicRequestError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingField(field) => write!(f, "Missing required field: {field}"),
+            Self::DecryptionError(msg) => write!(f, "Decryption failed: {msg}"),
+        }
+    }
+}
+
+impl core::error::Error for SeismicRequestError {}
 
 /// Builder for [`SeismicTypedTransaction`].
 #[derive(
@@ -220,62 +239,67 @@ impl SeismicTransactionRequest {
         Self::from_transaction(tx).from(from)
     }
 
+    /// Decrypts the input field using the seismic elements.
+    /// Returns `None` if there are no seismic elements (not a seismic tx).
+    /// Returns `Some(Err(...))` if decryption fails.
     fn decrypt_to_tx_request(
         &self,
         secret_key: &seismic_enclave::secp256k1::SecretKey,
-    ) -> Result<TransactionRequest, InputDecryptionElementsError> {
-        if self.seismic_elements.is_some() {
-            let sender = match self.from {
-                Some(addr) => addr,
-                None => {
-                    return Err(InputDecryptionElementsError::MissingField("sender"));
-                }
-            };
-            let tx_metadata = self.metadata(sender)?;
-            return match self.inner.input.input() {
-                Some(ciphertext) => {
-                    let plaintext = tx_metadata.decrypt(secret_key, ciphertext).map_err(|e| {
-                        InputDecryptionElementsError::DecryptionError(e.to_string())
-                    })?;
-                    Ok(self.inner.clone().input(alloy_primitives::Bytes::from(plaintext).into()))
-                }
-                None => Err(InputDecryptionElementsError::MissingField("input")),
-            };
+    ) -> Option<Result<TransactionRequest, SeismicRequestError>> {
+        if self.seismic_elements.is_none() {
+            return None;
         }
-        return Err(InputDecryptionElementsError::NoElements);
+        let sender = match self.from {
+            Some(addr) => addr,
+            None => {
+                return Some(Err(SeismicRequestError::MissingField("sender")));
+            }
+        };
+        let tx_metadata = match self.metadata(sender) {
+            Ok(m) => m,
+            Err(e) => return Some(Err(e)),
+        };
+        Some(match self.inner.input.input() {
+            Some(ciphertext) => {
+                let plaintext = tx_metadata
+                    .decrypt(secret_key, ciphertext)
+                    .map_err(|e| SeismicRequestError::DecryptionError(e.to_string()));
+                match plaintext {
+                    Ok(p) => Ok(self.inner.clone().input(alloy_primitives::Bytes::from(p).into())),
+                    Err(e) => Err(e),
+                }
+            }
+            None => Err(SeismicRequestError::MissingField("input")),
+        })
     }
 
     /// Decrypts the seismic elements and returns a [`TransactionRequest`].
     pub fn to_transaction_request(
         &self,
         secret_key: &seismic_enclave::secp256k1::SecretKey,
-    ) -> Result<TransactionRequest, InputDecryptionElementsError> {
+    ) -> Result<TransactionRequest, SeismicRequestError> {
         match self.transaction_type {
             Some(SEISMIC_TX_TYPE_ID) => {
-                // if there are no elements, throw an error
-                let tx_req = self.decrypt_to_tx_request(secret_key);
-                if tx_req.is_err() {
-                    println!("tx type but no elements: {tx_req:?}");
+                // Seismic tx type set — elements are required
+                match self.decrypt_to_tx_request(secret_key) {
+                    Some(result) => {
+                        if result.is_err() {
+                            println!("tx type but decryption failed: {result:?}");
+                        }
+                        result
+                    }
+                    None => Err(SeismicRequestError::MissingField("seismic_elements")),
                 }
-                tx_req
             }
             None => {
+                // No tx type — try to decrypt if elements exist, otherwise pass through
                 match self.decrypt_to_tx_request(secret_key) {
-                    // if there's no type, return the decrypted request
-                    // if the decryption actually works
-                    Ok(tx_req) => Ok(tx_req),
-                    Err(InputDecryptionElementsError::NoElements) => {
-                        // if there are no elements and no type,
-                        // then return the original request,
-                        // bc then we hit the default type
-                        Ok(self.inner.clone())
-                    }
-                    // if there's no type but there are elements,
-                    // and the decryption fails, return an error
-                    Err(e) => {
-                        println!("No elements & no tx type");
+                    Some(Ok(tx_req)) => Ok(tx_req),
+                    Some(Err(e)) => {
+                        println!("No tx type but has elements & decryption failed");
                         Err(e)
                     }
+                    None => Ok(self.inner.clone()),
                 }
             }
             _ => Ok(self.inner.clone()),
@@ -570,51 +594,51 @@ impl Decodable712 for SeismicTransactionRequest {
     }
 }
 
-impl InputDecryptionElements for SeismicTransactionRequest {
-    fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError> {
-        self.seismic_elements.ok_or(InputDecryptionElementsError::NoElements)
-    }
-
-    fn get_input(&self) -> Result<Bytes, InputDecryptionElementsError> {
-        match self.inner.input.clone().into_input() {
-            Some(input) => Ok(input),
-            None => Err(InputDecryptionElementsError::MissingField("input")),
-        }
-    }
-
-    fn set_input(
-        &mut self,
-        data: Bytes,
-    ) -> Result<(), seismic_alloy_consensus::InputDecryptionElementsError> {
-        let new_self = core::mem::take(self).input(data.into());
-        *self = new_self;
-        Ok(())
-    }
-
-    fn metadata(&self, sender: Address) -> Result<TxSeismicMetadata, InputDecryptionElementsError> {
-        Ok(TxSeismicMetadata {
-            sender,
-            legacy_fields: seismic_alloy_consensus::TxLegacyFields {
-                chain_id: self
-                    .chain_id
-                    .ok_or(InputDecryptionElementsError::MissingField("chain_id"))?,
-                nonce: self.nonce.ok_or(InputDecryptionElementsError::MissingField("nonce"))?,
-                to: self.to.ok_or(InputDecryptionElementsError::MissingField("to"))?,
-                value: self.value.unwrap_or_default(),
-            },
-            seismic_elements: self
-                .seismic_elements
-                .ok_or(InputDecryptionElementsError::NoElements)?,
-        })
-    }
-}
-
 // ============================================================================
 // NEW: Seismic transaction builder helpers and validation
 // Added for filler-based seismic transaction handling
 // ============================================================================
 
 impl SeismicTransactionRequest {
+    /// Returns tx metadata for encryption with AEAD.
+    /// Fails if required builder fields (chain_id, nonce, to, seismic_elements) are not set.
+    pub fn metadata(&self, sender: Address) -> Result<TxSeismicMetadata, SeismicRequestError> {
+        Ok(TxSeismicMetadata {
+            sender,
+            legacy_fields: seismic_alloy_consensus::TxLegacyFields {
+                chain_id: self.chain_id.ok_or(SeismicRequestError::MissingField("chain_id"))?,
+                nonce: self.nonce.ok_or(SeismicRequestError::MissingField("nonce"))?,
+                to: self.to.ok_or(SeismicRequestError::MissingField("to"))?,
+                value: self.value.unwrap_or_default(),
+            },
+            seismic_elements: self
+                .seismic_elements
+                .ok_or(SeismicRequestError::MissingField("seismic_elements"))?,
+        })
+    }
+
+    /// Creates a copy of the transaction with the input field decrypted to plaintext.
+    pub fn decrypt_input(
+        &self,
+        decryption_key: &seismic_enclave::secp256k1::SecretKey,
+        sender: Address,
+    ) -> Result<Self, SeismicRequestError> {
+        let mut tx = self.clone();
+        if tx.seismic_elements.is_some() {
+            let tx_metadata = self.metadata(sender)?;
+            let ciphertext = match self.inner.input.clone().into_input() {
+                Some(input) => input,
+                None => return Err(SeismicRequestError::MissingField("input")),
+            };
+            let decrypted_data = tx_metadata
+                .decrypt(decryption_key, &ciphertext)
+                .map_err(|e| SeismicRequestError::DecryptionError(e.to_string()))?;
+            tx = core::mem::take(&mut tx)
+                .input(alloy_primitives::Bytes::from(decrypted_data).into());
+        }
+        Ok(tx)
+    }
+
     /// Mark this transaction as a seismic transaction.
     /// Fillers will generate seismic elements and encrypt the input.
     pub fn seismic(mut self) -> Self {
@@ -701,23 +725,24 @@ impl AsMut<SeismicTransactionRequest> for WithOtherFields<SeismicTransactionRequ
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::Bytes;
 
     #[test]
     fn test_set_input_for_request() {
-        let mut req = SeismicTransactionRequest::from_transaction(TxEip1559::default());
-        let start_input = req.get_input().unwrap();
+        let req = SeismicTransactionRequest::from_transaction(TxEip1559::default());
+        let start_input = req.inner.input.input().cloned().unwrap_or_default();
         let data = Bytes::from("test");
         assert_ne!(data, start_input);
 
-        req.set_input(data.clone()).unwrap();
-        let end_input = req.get_input().unwrap();
+        let req = req.input(data.clone().into());
+        let end_input = req.inner.input.input().cloned().unwrap_or_default();
         assert_eq!(data, end_input);
     }
 
-    /// Regression test: get_input() must return an error instead of panicking
+    /// Regression test: input() must return None instead of panicking
     /// when called on a SeismicTransactionRequest with no input data.
     #[test]
-    fn get_input_returns_error_when_input_missing() {
+    fn input_returns_none_when_input_missing() {
         let req = SeismicTransactionRequest::default()
             .from(Address::ZERO)
             .nonce(0)
@@ -725,8 +750,7 @@ mod tests {
             .seismic_elements(TxSeismicElements::default())
             .seismic();
 
-        let result = req.get_input();
-        assert!(result.is_err(), "get_input should return Err when input is missing");
+        assert!(req.inner.input.input().is_none(), "input should be None when not set");
     }
 
     /// Regression test: to_transaction_request() must return an error instead of


### PR DESCRIPTION
`InputDecryptionElements` trait has become a bit of a mess: it comtains things completely unrelated to decryption (validate_blocks), and its getter methods return errors instead of options. This PR cleans up most of it.
                                                                                                                                                                                              
### seismic_elements() returns Option instead of Result

Renamed get_decryption_elements() to seismic_elements() and changed the return type from Result<TxSeismicElements, InputDecryptionElementsError> to Option<TxSeismicElements>. "Not a Seismic transaction" is None, not an error. This collapses the enum match impls from 5+ error arms to a simple Seismic => Some, _ => None.

### metadata() returns Option instead of Result                                                                                                                                                   

Same reasoning — non-Seismic types return None, not UnsupportedTxType.

### Removed InputDecryptionElementsError enum entirely

- NoElements — replaced by Option::None                                                                                                                                                     
- UnsupportedTxType — replaced by Option::None                                                                                                                                                
- MissingField — moved to new SeismicRequestError on SeismicTransactionRequest                                                                                                              
- DecryptionError — replaced by standalone DecryptionError struct                                                                                                                             

### Removed trait impl from SeismicTransactionRequest                                                                                                                                             

The request builder had its own failure modes (missing optional fields) that don't belong on the trait. metadata() and decrypt_input() are now standalone methods on the struct. The + InputDecryptionElements bound was removed from fillers, provider builder, and decrypt layer (they already had AsRef<SeismicTransactionRequest>).

Other cleanups:
- get_input() removed from trait — Transaction::input() (supertrait) provides it
- set_input() made infallible — every tx type can set its input
- plaintext_copy() renamed to decrypt_input()
- Added Transaction as a supertrait bound
- set_request_input / set_envelope_input on SeismicNetwork made infallible
                                                                                                                                                                                              
## Downstream impact (when bumping seismic-alloy dep)

Should be pretty easy/small cleanup:
- seismic-reth: rename get_decryption_elements → seismic_elements in SeismicTransactionSigned impl, update get_input signature, rename plaintext_copy → decrypt_input
- seismic-evm: replace InputDecryptionElementsError with DecryptionErrorin error.rs, rename plaintext_copy → decrypt_input
- seismic-foundry: replace InputDecryptionElementsError with DecryptionError, update metadata() call sites from Result to Option
- poker: no changes (only uses trait bounds, never calls methods directly)