### PR TITLE
ci: Unpin foundry and update deps

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           curl -L https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
           SEISMIC_BIN="${XDG_CONFIG_HOME:-$HOME}/.seismic/bin"
-          $SEISMIC_BIN/sfoundryup -C 8fc1bf6c774966ccc9bef3ddd2ff9ac63f8084e8
+          $SEISMIC_BIN/sfoundryup
           echo "$SEISMIC_BIN" >> $GITHUB_PATH
       # TODO(samlaf): run provider integration tests against nightly sanvil (sfoundryup -i nightly) as well
       - name: cargo test (provider integration against sanvil)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,5 +178,5 @@ alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", tag = "v
 alloy-genesis = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "863c1fe6c66502e75217c5dcd20f8238a0282b51" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }


### PR DESCRIPTION
Ci fail expected, we need to cut a new release of `seismic-foundry` and then manually rerun to get passing