### PR TITLE
fix(tx-envelope): reject signed-read writes at decode time

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -14,7 +14,7 @@ use alloy_eips::{
     eip7702::SignedAuthorization,
 };
 use alloy_primitives::{Address, Bytes, Signature, TxKind, B256, U256};
-use alloy_rlp::{Decodable, Encodable};
+use alloy_rlp::{Buf, Decodable, Encodable};
 use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "serde")]
@@ -669,6 +669,112 @@ impl Decodable for SeismicTxEnvelope {
     }
 }
 
+impl<Eip4844> SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
+    /// Shared typed-decode body for both the strict [`Decodable2718`] impl and the
+    /// permissive [`Self::decode_2718_permit_seismic_calls`] entry point.
+    ///
+    /// When `reject_signed_reads` is `true` (block / mempool / p2p / `eth_sendRawTransaction`
+    /// paths), any seismic transaction carrying `signed_read = true` with a non-create
+    /// `to` is rejected at decode time. Signed reads are intended for the RPC `eth_call`
+    /// path only; allowing them through would let an attacker who intercepted a signed
+    /// `eth_call` payload replay it as an actual state-changing transaction.
+    fn typed_decode_inner(
+        ty: u8,
+        buf: &mut &[u8],
+        reject_signed_reads: bool,
+    ) -> Eip2718Result<Self> {
+        match ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))? {
+            SeismicTxType::Eip2930 => Ok(Self::Eip2930(TxEip2930::rlp_decode_signed(buf)?)),
+            SeismicTxType::Eip1559 => Ok(Self::Eip1559(TxEip1559::rlp_decode_signed(buf)?)),
+            SeismicTxType::Eip4844 => Ok(Self::Eip4844(Eip4844::rlp_decode_signed(buf)?)),
+            SeismicTxType::Eip7702 => Ok(Self::Eip7702(TxEip7702::rlp_decode_signed(buf)?)),
+            SeismicTxType::Seismic => {
+                let tx = TxSeismic::rlp_decode_signed(buf)?;
+                // TODO(signed-read wire-format split): reserve a distinct EIP-2718 type
+                // byte (e.g. `0x4B`) for signed-read calls, and remove the `signed_read`
+                // field from `TxSeismicElements` entirely, which would delete this
+                // whole runtime check.
+                //
+                // Today, writes and signed-reads share type byte `0x4A` and are
+                // distinguished only by the in-body `signed_read` flag. Two problems:
+                //
+                // 1. **Signature-ingress metadata leaks into chain storage.** `signed_read` is a
+                //    discriminator for how a payload should be treated at RPC/mempool ingress. It
+                //    has no semantic effect on execution or state, yet every Seismic tx ever
+                //    included in a block carries the byte — effectively always `false` for chain
+                //    txs. Chain data should be transaction data, not signature-protocol metadata.
+                //
+                // 2. **The invariant is runtime-enforced and has already failed open once.** Replay
+                //    protection (a signed-read payload must not re-execute as a write) lives in
+                //    *this* check. Any ingress path that doesn't funnel through
+                //    `Decodable2718::typed_decode` skips it. The `SeismicRawTxRequest::TypedData`
+                //    RPC path was one such path historically (hence the server-side re-encode now
+                //    in `send_raw_transaction`).
+                //
+                // With a distinct type byte both problems vanish structurally:
+                //
+                // * `signed_read` disappears from `TxSeismicElements`, and chain storage / sighash
+                //   preimages stop carrying it.
+                // * The strict `SeismicTxEnvelope` enum cannot represent a signed-read tx: decoding
+                //   `0x4B` on any block/mempool/p2p path fails with `Eip2718Error::UnexpectedType`.
+                //   Replay protection becomes a type-system property rather than a
+                //   discipline-to-run-the-check property.
+                // * The type byte is part of the sighash preimage, so a signature over a `0x4B`
+                //   payload cannot be reinterpreted as a signature over a `0x4A` write tx —
+                //   cryptographic domain separation for free, without relying solely on the EIP-712
+                //   domain.
+                //
+                // The eth_call RPC path would decode `0x4B` via a separate envelope
+                // type (or permissive decoder) scoped to that path only.
+                //
+                // Cost: hard fork of the wire format; coordinated updates across
+                // seismic-reth, sanvil (seismic-foundry), seismic-alloy providers,
+                // explorers, and indexers.
+                if reject_signed_reads &&
+                    tx.tx().seismic_elements.signed_read &&
+                    !tx.tx().to.is_create()
+                {
+                    return Err(alloy_rlp::Error::Custom(
+                        "signed-read seismic transactions cannot appear in blocks or the mempool",
+                    )
+                    .into());
+                }
+                Ok(Self::Seismic(tx))
+            }
+            SeismicTxType::Legacy => {
+                Err(alloy_rlp::Error::Custom("type-0 eip2718 transactions are not supported")
+                    .into())
+            }
+        }
+    }
+
+    /// Decode an EIP-2718 transaction, permissively accepting seismic transactions
+    /// with `signed_read = true`.
+    ///
+    /// Intended for the RPC `eth_call` raw-bytes path, which legitimately receives
+    /// signed seismic read requests. **Do not** use this for block, mempool, p2p, or
+    /// `eth_sendRawTransaction` decoding — those paths must go through the strict
+    /// [`Decodable2718::decode_2718`] to ensure signed-read payloads cannot be
+    /// replayed as state-changing transactions.
+    pub fn decode_2718_permit_seismic_calls(buf: &mut &[u8]) -> Eip2718Result<Self> {
+        match Self::extract_type_byte(buf) {
+            Some(ty) => {
+                buf.advance(1);
+                Self::typed_decode_inner(ty, buf, false)
+            }
+            None => Self::fallback_decode(buf),
+        }
+    }
+}
+
 impl<Eip4844> Decodable2718 for SeismicTxEnvelope<Eip4844>
 where
     Eip4844: RlpEcdsaEncodableTx
@@ -679,17 +785,7 @@ where
         + SignableTransaction<Signature>,
 {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
-        match ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))? {
-            SeismicTxType::Eip2930 => Ok(Self::Eip2930(TxEip2930::rlp_decode_signed(buf)?)),
-            SeismicTxType::Eip1559 => Ok(Self::Eip1559(TxEip1559::rlp_decode_signed(buf)?)),
-            SeismicTxType::Eip4844 => Ok(Self::Eip4844(Eip4844::rlp_decode_signed(buf)?)),
-            SeismicTxType::Eip7702 => Ok(Self::Eip7702(TxEip7702::rlp_decode_signed(buf)?)),
-            SeismicTxType::Seismic => Ok(Self::Seismic(TxSeismic::rlp_decode_signed(buf)?)),
-            SeismicTxType::Legacy => {
-                Err(alloy_rlp::Error::Custom("type-0 eip2718 transactions are not supported")
-                    .into())
-            }
-        }
+        Self::typed_decode_inner(ty, buf, true)
     }
 
     fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
@@ -929,5 +1025,78 @@ mod tests {
         let mut slice = encoded.as_slice();
         let decoded = SeismicTxEnvelope::<TxEip1559>::decode_2718(&mut slice).unwrap();
         assert!(matches!(decoded, SeismicTxEnvelope::Eip1559(_)));
+    }
+
+    /// Build a signed seismic tx envelope for decode testing.
+    fn signed_seismic_envelope(signed_read: bool, to: TxKind) -> Vec<u8> {
+        let tx = TxSeismic {
+            chain_id: 1,
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to,
+            value: U256::ZERO,
+            seismic_elements: TxSeismicElements { signed_read, ..Default::default() },
+            input: Default::default(),
+            authorization_list: vec![],
+        };
+        let sig = Signature::test_signature();
+        let envelope: SeismicTxEnvelope = SeismicTxEnvelope::Seismic(tx.into_signed(sig));
+        envelope.encoded_2718()
+    }
+
+    /// Strict [`Decodable2718::decode_2718`] must reject a signed-read seismic tx
+    /// that has a non-create `to` — this is the block/mempool/p2p guard.
+    #[test]
+    fn strict_decode_rejects_signed_read_write() {
+        let encoded = signed_seismic_envelope(true, Address::left_padding_from(&[1]).into());
+
+        let mut slice = encoded.as_slice();
+        let result = <SeismicTxEnvelope>::decode_2718(&mut slice);
+
+        assert!(
+            result.is_err(),
+            "strict decode must reject signed-read seismic tx with non-create `to`"
+        );
+    }
+
+    /// Permissive decoder accepts the same bytes — this is the eth_call path.
+    #[test]
+    fn permissive_decode_accepts_signed_read_write() {
+        let encoded = signed_seismic_envelope(true, Address::left_padding_from(&[1]).into());
+
+        let mut slice = encoded.as_slice();
+        let decoded = <SeismicTxEnvelope>::decode_2718_permit_seismic_calls(&mut slice)
+            .expect("permissive decode must accept signed-read seismic tx");
+
+        assert!(
+            matches!(decoded, SeismicTxEnvelope::Seismic(ref s) if s.tx().seismic_elements.signed_read)
+        );
+    }
+
+    /// Non-signed-read seismic txs are valid on both paths.
+    #[test]
+    fn both_decoders_accept_non_signed_read() {
+        let encoded = signed_seismic_envelope(false, Address::left_padding_from(&[1]).into());
+
+        let mut slice = encoded.as_slice();
+        <SeismicTxEnvelope>::decode_2718(&mut slice)
+            .expect("strict decode must accept non-signed-read seismic tx");
+
+        let mut slice = encoded.as_slice();
+        <SeismicTxEnvelope>::decode_2718_permit_seismic_calls(&mut slice)
+            .expect("permissive decode must accept non-signed-read seismic tx");
+    }
+
+    /// A contract-creation tx (`to = Create`) with `signed_read = true` is not
+    /// rejected, mirroring the original mempool rule (`!to.is_create() && signed_read`).
+    /// This test pins that behavior so we notice if the rule changes.
+    #[test]
+    fn strict_decode_accepts_signed_read_create() {
+        let encoded = signed_seismic_envelope(true, TxKind::Create);
+
+        let mut slice = encoded.as_slice();
+        <SeismicTxEnvelope>::decode_2718(&mut slice)
+            .expect("strict decode accepts signed-read + create");
     }
 }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -682,10 +682,10 @@ where
     /// permissive [`Self::decode_2718_permit_seismic_calls`] entry point.
     ///
     /// When `reject_signed_reads` is `true` (block / mempool / p2p / `eth_sendRawTransaction`
-    /// paths), any seismic transaction carrying `signed_read = true` with a non-create
-    /// `to` is rejected at decode time. Signed reads are intended for the RPC `eth_call`
-    /// path only; allowing them through would let an attacker who intercepted a signed
-    /// `eth_call` payload replay it as an actual state-changing transaction.
+    /// paths), any seismic transaction carrying `signed_read = true` is rejected at decode
+    /// time, regardless of `to`. Signed reads are intended for the RPC `eth_call` path only;
+    /// allowing them through would let an attacker who intercepted a signed `eth_call` payload
+    /// replay it as an actual state-changing transaction.
     fn typed_decode_inner(
         ty: u8,
         buf: &mut &[u8],
@@ -707,10 +707,7 @@ where
                 // make signed-reads simply sign a different hash preimage than writes,
                 // making signature replay between the two intents impossible: `ecrecover` on the
                 // write preimage returns a garbage address unrelated to the original signer.
-                if reject_signed_reads &&
-                    tx.tx().seismic_elements.signed_read &&
-                    !tx.tx().to.is_create()
-                {
+                if reject_signed_reads && tx.tx().seismic_elements.signed_read {
                     return Err(alloy_rlp::Error::Custom(
                         "signed-read seismic transactions cannot appear in blocks or the mempool",
                     )
@@ -1057,15 +1054,16 @@ mod tests {
             .expect("permissive decode must accept non-signed-read seismic tx");
     }
 
-    /// A contract-creation tx (`to = Create`) with `signed_read = true` is not
-    /// rejected, mirroring the original mempool rule (`!to.is_create() && signed_read`).
-    /// This test pins that behavior so we notice if the rule changes.
+    /// Signed reads are rejected regardless of `to`: a contract-creation tx (`to = Create`)
+    /// with `signed_read = true` is rejected by the strict decoder just like a signed-read call.
     #[test]
-    fn strict_decode_accepts_signed_read_create() {
+    fn strict_decode_rejects_signed_read_create() {
         let encoded = signed_seismic_envelope(true, TxKind::Create);
 
         let mut slice = encoded.as_slice();
-        <SeismicTxEnvelope>::decode_2718(&mut slice)
-            .expect("strict decode accepts signed-read + create");
+        assert!(
+            <SeismicTxEnvelope>::decode_2718(&mut slice).is_err(),
+            "strict decode must reject signed-read + create"
+        );
     }
 }

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -698,46 +698,15 @@ where
             SeismicTxType::Eip7702 => Ok(Self::Eip7702(TxEip7702::rlp_decode_signed(buf)?)),
             SeismicTxType::Seismic => {
                 let tx = TxSeismic::rlp_decode_signed(buf)?;
-                // TODO(signed-read wire-format split): reserve a distinct EIP-2718 type
-                // byte (e.g. `0x4B`) for signed-read calls, and remove the `signed_read`
-                // field from `TxSeismicElements` entirely, which would delete this
-                // whole runtime check.
-                //
-                // Today, writes and signed-reads share type byte `0x4A` and are
-                // distinguished only by the in-body `signed_read` flag. Two problems:
-                //
-                // 1. **Signature-ingress metadata leaks into chain storage.** `signed_read` is a
-                //    discriminator for how a payload should be treated at RPC/mempool ingress. It
-                //    has no semantic effect on execution or state, yet every Seismic tx ever
-                //    included in a block carries the byte — effectively always `false` for chain
-                //    txs. Chain data should be transaction data, not signature-protocol metadata.
-                //
-                // 2. **The invariant is runtime-enforced and has already failed open once.** Replay
-                //    protection (a signed-read payload must not re-execute as a write) lives in
-                //    *this* check. Any ingress path that doesn't funnel through
-                //    `Decodable2718::typed_decode` skips it. The `SeismicRawTxRequest::TypedData`
-                //    RPC path was one such path historically (hence the server-side re-encode now
-                //    in `send_raw_transaction`).
-                //
-                // With a distinct type byte both problems vanish structurally:
-                //
-                // * `signed_read` disappears from `TxSeismicElements`, and chain storage / sighash
-                //   preimages stop carrying it.
-                // * The strict `SeismicTxEnvelope` enum cannot represent a signed-read tx: decoding
-                //   `0x4B` on any block/mempool/p2p path fails with `Eip2718Error::UnexpectedType`.
-                //   Replay protection becomes a type-system property rather than a
-                //   discipline-to-run-the-check property.
-                // * The type byte is part of the sighash preimage, so a signature over a `0x4B`
-                //   payload cannot be reinterpreted as a signature over a `0x4A` write tx —
-                //   cryptographic domain separation for free, without relying solely on the EIP-712
-                //   domain.
-                //
-                // The eth_call RPC path would decode `0x4B` via a separate envelope
-                // type (or permissive decoder) scoped to that path only.
-                //
-                // Cost: hard fork of the wire format; coordinated updates across
-                // seismic-reth, sanvil (seismic-foundry), seismic-alloy providers,
-                // explorers, and indexers.
+                // TODO(samlaf): transform this replaying-signed-read-as-write invariant
+                // into a cryptographic property of the signature scheme rather than a runtime
+                // check. Right now if anyone adds a new ingress path (like we had
+                // for eip-712 signatures) that doesn't go through this 2718 decode
+                // has a potential to have a replayability bug. We should probably
+                // remove the `signed_read` byte from the tx rlp and instead
+                // make signed-reads simply sign a different hash preimage than writes,
+                // making signature replay between the two intents impossible: `ecrecover` on the
+                // write preimage returns a garbage address unrelated to the original signer.
                 if reject_signed_reads &&
                     tx.tx().seismic_elements.signed_read &&
                     !tx.tx().to.is_create()

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -25,6 +25,7 @@ alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-network-primitives.workspace = true
 alloy-primitives.workspace = true
+alloy-rlp.workspace = true
 alloy-provider.workspace = true
 alloy-rpc-client.workspace = true
 alloy-rpc-types-eth.workspace = true

--- a/crates/network/src/foundry/envelope.rs
+++ b/crates/network/src/foundry/envelope.rs
@@ -152,6 +152,17 @@ impl Decodable2718 for SeismicFoundryTxEnvelope {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> alloy_network::eip2718::Eip2718Result<Self> {
         if ty == TxSeismic::TX_TYPE {
             let tx = TxSeismic::rlp_decode_signed(buf)?;
+            // Reject every signed-read seismic tx at decode time. Signed reads are an RPC
+            // `eth_call`-only construct; admitting one as a state transition (call or create)
+            // would let an attacker replay an intercepted signed `eth_call` payload as a real
+            // write. This is sanvil's (dev-tool) network decoder, gated for dev/prod parity with
+            // the same guard in reth's consensus `SeismicTransactionSigned::typed_decode`.
+            if tx.tx().seismic_elements.signed_read {
+                return Err(alloy_rlp::Error::Custom(
+                    "signed-read seismic transactions cannot appear in blocks or the mempool",
+                )
+                .into());
+            }
             Ok(SeismicFoundryTxEnvelope::Seismic(tx))
         } else {
             let tx = AnyTxEnvelope::typed_decode(ty, buf)?;
@@ -457,5 +468,69 @@ impl InputDecryptionElements for SeismicFoundryTxEnvelope {
                 Err(InputDecryptionElementsError::UnsupportedTxType("Unknown".to_string()))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::SignableTransaction;
+    use alloy_primitives::aliases::U96;
+    use seismic_alloy_consensus::TxSeismicElements;
+
+    /// Build the EIP-2718 bytes of a signed seismic tx with the given `signed_read`/`to`.
+    /// The signature is arbitrary: the decoder gates on `signed_read` before any recovery,
+    /// so a dummy signature exercises the path we care about.
+    fn encoded_seismic_tx(signed_read: bool, to: TxKind) -> Vec<u8> {
+        let tx = TxSeismic {
+            chain_id: 31337u64,
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to,
+            value: U256::ZERO,
+            input: Bytes::new(),
+            seismic_elements: TxSeismicElements {
+                encryption_nonce: U96::ZERO,
+                signed_read,
+                ..Default::default()
+            },
+            authorization_list: vec![],
+        };
+        let signature = Signature::new(U256::from(1u64), U256::from(1u64), false);
+        let envelope = SeismicFoundryTxEnvelope::Seismic(tx.into_signed(signature));
+        let mut buf = Vec::new();
+        envelope.encode_2718(&mut buf);
+        buf
+    }
+
+    /// The sanvil decoder must reject a signed-read seismic call tx, matching reth's
+    /// consensus-decoder gate, so a replayed signed `eth_call` can't enter a block/mempool.
+    #[test]
+    fn decode_2718_rejects_signed_read_write() {
+        let encoded = encoded_seismic_tx(true, TxKind::Call(Address::with_last_byte(1)));
+        assert!(
+            SeismicFoundryTxEnvelope::decode_2718(&mut &encoded[..]).is_err(),
+            "sanvil decoder must reject signed-read seismic call tx"
+        );
+    }
+
+    /// A signed-read create is rejected too: a create is also a state transition, so there's no
+    /// legitimate signed-read create on a block/mempool ingress path.
+    #[test]
+    fn decode_2718_rejects_signed_read_create() {
+        let encoded = encoded_seismic_tx(true, TxKind::Create);
+        assert!(
+            SeismicFoundryTxEnvelope::decode_2718(&mut &encoded[..]).is_err(),
+            "sanvil decoder must reject signed-read seismic create tx"
+        );
+    }
+
+    /// Ordinary (non-signed-read) seismic writes must still decode unaffected.
+    #[test]
+    fn decode_2718_accepts_non_signed_read_write() {
+        let encoded = encoded_seismic_tx(false, TxKind::Call(Address::with_last_byte(1)));
+        SeismicFoundryTxEnvelope::decode_2718(&mut &encoded[..])
+            .expect("non-signed-read seismic write must decode");
     }
 }

--- a/crates/rpc-types/src/request.rs
+++ b/crates/rpc-types/src/request.rs
@@ -11,7 +11,22 @@ use crate::SeismicTransactionRequest;
 pub enum SeismicRawTxRequest {
     /// A raw seismic tx
     Bytes(Bytes),
-    /// An EIP-712 typed data request with a signature
+    /// An EIP-712 typed data request with a signature.
+    ///
+    /// TODO(deprecate TypedData RPC variant): this variant is a convenience for wallets
+    /// that can sign EIP-712 typed data but don't natively produce RLP-encoded `0x4A`
+    /// transactions. It carries no information that isn't equally expressible as an
+    /// RLP-encoded `TxSeismic` with `message_version = 2` and the EIP-712 signature,
+    /// which clients can submit via the [`Self::Bytes`] variant instead. The server
+    /// currently handles this variant by re-encoding to RLP internally (see
+    /// `send_raw_transaction` in seismic-reth's `ext.rs`) so all signed-tx ingress
+    /// funnels through the single `Decodable2718::typed_decode` pipeline.
+    ///
+    /// Clients should migrate to submitting RLP bytes via `Bytes`. This variant is
+    /// planned for removal in a future hard fork, ideally alongside the wire-format
+    /// split that replaces `message_version` with a distinct EIP-2718 type byte
+    /// (`0x4C`) — see the companion TODOs in seismic-alloy's `envelope.rs` (for
+    /// `0x4B` signed-reads) and seismic-reth's `ext.rs` (for `0x4C` EIP-712 writes).
     TypedData(TypedDataRequest),
 }
 

--- a/crates/rpc-types/src/request.rs
+++ b/crates/rpc-types/src/request.rs
@@ -11,22 +11,16 @@ use crate::SeismicTransactionRequest;
 pub enum SeismicRawTxRequest {
     /// A raw seismic tx
     Bytes(Bytes),
-    /// An EIP-712 typed data request with a signature.
-    ///
-    /// TODO(deprecate TypedData RPC variant): this variant is a convenience for wallets
+    /// An EIP-712 typed data request with a signature; this variant is a convenience for wallets
     /// that can sign EIP-712 typed data but don't natively produce RLP-encoded `0x4A`
-    /// transactions. It carries no information that isn't equally expressible as an
-    /// RLP-encoded `TxSeismic` with `message_version = 2` and the EIP-712 signature,
-    /// which clients can submit via the [`Self::Bytes`] variant instead. The server
-    /// currently handles this variant by re-encoding to RLP internally (see
-    /// `send_raw_transaction` in seismic-reth's `ext.rs`) so all signed-tx ingress
-    /// funnels through the single `Decodable2718::typed_decode` pipeline.
+    /// transactions.
     ///
-    /// Clients should migrate to submitting RLP bytes via `Bytes`. This variant is
-    /// planned for removal in a future hard fork, ideally alongside the wire-format
-    /// split that replaces `message_version` with a distinct EIP-2718 type byte
-    /// (`0x4C`) — see the companion TODOs in seismic-alloy's `envelope.rs` (for
-    /// `0x4B` signed-reads) and seismic-reth's `ext.rs` (for `0x4C` EIP-712 writes).
+    /// TODO(samlaf): this type/path carries no information that isn't equally expressible as an
+    /// RLP-encoded `TxSeismic` with the EIP-712 signature attached, which clients can
+    /// submit via the [`Self::Bytes`] variant instead. Reth currently handles this variant
+    /// by re-encoding to RLP internally anyways. Clients should migrate to submitting RLP bytes
+    /// via `Bytes`; once done, this variant can be removed entirely and the server's re-encode
+    /// logic collapses.
     TypedData(TypedDataRequest),
 }
 


### PR DESCRIPTION
Enforce the signed-read rejection invariant at the EIP-2718 decode layer. Each ingress path 
decodes into a different type with its own Decodable2718 impl, so the invariant must live in 
each. This PR adds it to SeismicTxEnvelope::typed_decode (the pooled/RPC type — 
eth_sendRawTransaction and p2p transaction gossip) and SeismicFoundryTxEnvelope::typed_decode
(sanvil). The block-ingestion paths (engine API newPayload, block-body decode, the block 
executor) decode via seismic-reth's consensus type SeismicTransactionSigned::typed_decode; 
that guard is the companion seismic-reth change (https://github.com/SeismicSystems/seismic-reth/pull/422).

Previously the invariant lived only in seismic-reth's mempool validator, bypassed by any 
block producer ingesting txs through non-mempool paths (builder API, private orderflow, 
direct block construction). A malicious producer could include a signed-read tx directly in a
block, letting an attacker who intercepted a signed eth_call payload replay it as a 
state-changing transaction.

## Future hard-fork requiring change to SeismicTx

Added a TODO in envelope.rs proposing to get rid of `signed_read` as part of the rlp format, and instead move the check as part of the rpc layer (0x4B type) or signing domain (sign a different prefix).

Here are possible alternatives:
1. **Different sighash domain** (smallest structural change): keep wire type byte `0x4A`; reads and writes sign different hash preimages — for EIP-712 via different `domain.name`/`version`, for RLP via a prefix byte prepended before `rlp(payload)`. Wire format otherwise unchanged.
2. **Mandatory EIP-712 for `TxSeismic`** (zkSync-style, scoped to this tx type — other EIP-2718 tx types on Seismic continue to use RLP sighash): reads and writes use different EIP-712 domains. Also deletes `message_version` and the `SeismicRawTxRequest::TypedData` RPC variant. Cost: ~10× more keccak calls per sighash than RLP.
3. **EIP-2718 type byte split** (e.g. `0x4B` for reads): type-system enforcement. Caveat: a `0x4B` payload would have the same wire layout as `0x4A`, so this uses 2718's discriminator for what's really a handling / signing intent rather than a tx-shape distinction — an unusual (though not spec-violating) use of the mechanism.
4. **Seismic meta-envelope wrapping 2718**: outer wrapper carries intent / signing metadata; inner is a standard 2718 tx. Clean layering but introduces a novel wire layer that every piece of tx tooling (p2p, block bodies, trie roots, explorers, indexers) must understand.