### PR TITLE
chore(deps): migrate enclave crypto helpers to seismic-crypto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ This prevents replay attacks and ensures transactions are only valid for a speci
 
 The project depends on custom forks of several upstream libraries:
 
-- **seismic-enclave**: Enclave integration for ECDH encryption/decryption (pinned to specific commit)
+- **seismic-crypto**: Shared AES-GCM / ECDH / HKDF helpers and secp256k1 re-export (pinned to specific commit)
 - **seismic-alloy-core**: Custom Alloy primitives with Seismic ABI support
 - **seismic-revm**: Modified REVM for executing Seismic transactions
 - **seismic-trie**: Custom Merkle trie implementation
@@ -210,7 +210,7 @@ The test job runs on a self-hosted runner with sanvil configured.
 
 ### Seismic-Specific
 
-- **seismic-enclave** - Enclave integration (custom fork, commit-pinned)
+- **seismic-crypto** - Shared crypto helpers from the enclave repo (custom fork, commit-pinned)
 - **seismic-alloy-core** - Seismic primitives (custom fork)
 - **seismic-revm** - Modified EVM (custom fork)
 - **seismic-trie** - Merkle trie (custom fork)
@@ -285,7 +285,7 @@ Seismic transactions expire after the specified block number. This prevents long
 Based on recent commits:
 
 - **Transaction state pinning** - Pin state during transaction execution for consistency
-- **Enclave updates** - Updated seismic-enclave commit reference
+- **Crypto facade removal** - Migrated crypto helper imports from `seismic-enclave` to `seismic-crypto`
 - **EIP-4844 generics** - Improved generic handling for blob transactions
 - **Direct key-based encryption** - Removed enclave client dependency, now uses direct key-based encryption
 
@@ -318,7 +318,7 @@ Use the test utilities in `crates/provider/src/test_utils.rs`. Tests typically s
 
 ### Avoid
 
-- Do not modify vendored dependencies (seismic-enclave, seismic-revm, etc.) directly in this repo
+- Do not modify vendored dependencies (seismic-crypto, seismic-revm, etc.) directly in this repo
 - Do not change the Seismic transaction type ID (0x4A / 74) without chain upgrade coordination
 - Do not add dependencies that conflict with Alloy's version requirements
 - Do not implement partial features - ensure encryption/decryption pairs are complete
@@ -327,7 +327,7 @@ Use the test utilities in `crates/provider/src/test_utils.rs`. Tests typically s
 ## Additional Resources
 
 - **Alloy Documentation**: https://alloy.rs
-- **Seismic Enclave**: https://github.com/SeismicSystems/seismic-enclave
+- **Seismic Crypto / Enclave Repo**: https://github.com/SeismicSystems/enclave
 - **Ethereum EIPs**: https://eips.ethereum.org (for understanding standard transaction types)
 
 ## Essential Commands

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ seismic-alloy-network = { version = "0.0.1", path = "crates/network", default-fe
 seismic-alloy-provider = { version = "0.0.1", path = "crates/provider", default-features = false }
 seismic-prelude = { version = "0.0.1", path = "crates/prelude" }
 
-seismic-enclave = "0.1.0"
+seismic-crypto = "0.1.0"
 
 revm = { version = "29.0.0", default-features = false }
 seismic-revm = "1.0.0"
@@ -142,8 +142,8 @@ c-kzg = { version = "2.1.1", default-features = false }
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
 [patch.crates-io]
-# Seismic enclave
-seismic-enclave =  { git = "https://github.com/SeismicSystems/enclave.git", rev = "f90b02f38a6190e8b2ff2d051d9043f3480cd3ac" }
+# seismic-crypto
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
 
 # seismic-alloy-core
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -178,5 +178,5 @@ alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", tag = "v
 alloy-genesis = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "dc05eece19f14516ab9f996611fa7c63e1d1a8ae" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7a3dd39011f9e2566f4b8663406f48939c00bc6f" }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -15,7 +15,7 @@ exclude.workspace = true
 workspace = true
 
 [dependencies]
-seismic-enclave.workspace = true
+seismic-crypto.workspace = true
 
 alloy-eips = { workspace = true, features = ["kzg-sidecar"] }
 alloy-primitives = { workspace = true, features = ["rlp", "seismic"] }

--- a/crates/consensus/src/transaction/metadata.rs
+++ b/crates/consensus/src/transaction/metadata.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rlp::Encodable;
-use seismic_enclave::secp256k1::{PublicKey, SecretKey};
+use seismic_crypto::secp256k1::{PublicKey, SecretKey};
 
 use super::seismic::TxSeismicElements;
 

--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -12,7 +12,7 @@ use alloy_rlp::{BufMut, Decodable, Encodable};
 use alloy_serde::WithOtherFields;
 use core::mem;
 use rand::RngCore;
-use seismic_enclave::{
+use seismic_crypto::{
     ecdh_decrypt_aead, ecdh_encrypt_aead,
     secp256k1::{constants, Keypair, PublicKey, Secp256k1, SecretKey},
     Nonce,
@@ -1123,7 +1123,7 @@ mod tests {
         hex::{self, FromHex},
         Address, FixedBytes, Signature,
     };
-    use seismic_enclave::{get_unsecure_sample_secp256k1_pk, get_unsecure_sample_secp256k1_sk};
+    use seismic_crypto::{get_unsecure_sample_secp256k1_pk, get_unsecure_sample_secp256k1_sk};
 
     use super::*;
 

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 # Workspace
 seismic-alloy-consensus.workspace = true
 seismic-alloy-rpc-types = { workspace = true, features = ["serde"] }
-seismic-enclave.workspace = true
+seismic-crypto.workspace = true
 
 # Alloy
 alloy-consensus.workspace = true

--- a/crates/network/src/fillers.rs
+++ b/crates/network/src/fillers.rs
@@ -17,7 +17,7 @@ use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_transport::{TransportErrorKind, TransportResult};
 use seismic_alloy_consensus::{InputDecryptionElements, TxSeismicElements};
 use seismic_alloy_rpc_types::SeismicTransactionRequest;
-use seismic_enclave::secp256k1::{PublicKey, Secp256k1};
+use seismic_crypto::secp256k1::{PublicKey, Secp256k1};
 use std::str::FromStr;
 
 pub use alloy_provider::fillers::GasFiller;
@@ -211,7 +211,7 @@ pub struct SeismicElementsFiller {
     /// Custom blocks window for transaction expiration (overrides BLOCKS_WINDOW)
     blocks_window: Option<u64>,
     /// Client's provider secret key for encryption/decryption (generated once at client creation)
-    provider_secret_key: seismic_enclave::secp256k1::SecretKey,
+    provider_secret_key: seismic_crypto::secp256k1::SecretKey,
     /// Whether seismic calls should be marked as signed_read (true for signed providers)
     signed_read: bool,
 }
@@ -253,7 +253,7 @@ impl SeismicElementsFiller {
     }
 
     /// Get the provider secret key for response decryption
-    pub fn provider_secret_key(&self) -> &seismic_enclave::secp256k1::SecretKey {
+    pub fn provider_secret_key(&self) -> &seismic_crypto::secp256k1::SecretKey {
         &self.provider_secret_key
     }
 
@@ -279,7 +279,7 @@ where
     // to encrypt
     type Fillable = Option<(
         PublicKey,
-        seismic_enclave::secp256k1::SecretKey,
+        seismic_crypto::secp256k1::SecretKey,
         TxSeismicElements,
         alloy_primitives::Bytes,
     )>;

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -26,7 +26,7 @@ alloy-sol-types.workspace = true
 seismic-alloy-consensus.workspace = true
 seismic-alloy-network.workspace = true
 seismic-alloy-rpc-types.workspace = true
-seismic-enclave.workspace = true
+seismic-crypto.workspace = true
 
 async-trait.workspace = true
 reqwest.workspace = true

--- a/crates/provider/src/builder.rs
+++ b/crates/provider/src/builder.rs
@@ -248,7 +248,7 @@ where
     pub fn connect_http_with_tee_pubkey(
         self,
         url: reqwest::Url,
-        tee_pubkey: seismic_enclave::secp256k1::PublicKey,
+        tee_pubkey: seismic_crypto::secp256k1::PublicKey,
     ) -> SeismicSignedProvider<N> {
         let (filler_chain, provider_secret_key) = self.signed_filler_chain(url.clone(), tee_pubkey);
 
@@ -274,7 +274,7 @@ where
     pub async fn connect_ws_with_tee_pubkey(
         self,
         url: reqwest::Url,
-        tee_pubkey: seismic_enclave::secp256k1::PublicKey,
+        tee_pubkey: seismic_crypto::secp256k1::PublicKey,
     ) -> TransportResult<SeismicSignedProvider<N>> {
         let (filler_chain, provider_secret_key) = self.signed_filler_chain(url.clone(), tee_pubkey);
 
@@ -291,8 +291,8 @@ where
     fn signed_filler_chain(
         self,
         url: reqwest::Url,
-        tee_pubkey: seismic_enclave::secp256k1::PublicKey,
-    ) -> (SignedFillers<N>, seismic_enclave::secp256k1::SecretKey) {
+        tee_pubkey: seismic_crypto::secp256k1::PublicKey,
+    ) -> (SignedFillers<N>, seismic_crypto::secp256k1::SecretKey) {
         let seismic_filler = SeismicElementsFiller::with_tee_pubkey(tee_pubkey);
         let provider_secret_key = seismic_filler.provider_secret_key().clone();
 

--- a/crates/provider/src/decrypt.rs
+++ b/crates/provider/src/decrypt.rs
@@ -30,8 +30,8 @@ use crate::{SeismicProviderExt, SignedProviderExt};
 #[derive(Debug, Clone)]
 pub struct ResponseDecryptProvider<N, P> {
     inner: P,
-    provider_secret_key: seismic_enclave::secp256k1::SecretKey,
-    tee_pubkey: seismic_enclave::secp256k1::PublicKey,
+    provider_secret_key: seismic_crypto::secp256k1::SecretKey,
+    tee_pubkey: seismic_crypto::secp256k1::PublicKey,
     _network: std::marker::PhantomData<N>,
 }
 
@@ -39,8 +39,8 @@ impl<N, P> ResponseDecryptProvider<N, P> {
     /// Create a new response-decrypting provider.
     pub fn new(
         inner: P,
-        provider_secret_key: seismic_enclave::secp256k1::SecretKey,
-        tee_pubkey: seismic_enclave::secp256k1::PublicKey,
+        provider_secret_key: seismic_crypto::secp256k1::SecretKey,
+        tee_pubkey: seismic_crypto::secp256k1::PublicKey,
     ) -> Self {
         Self { inner, provider_secret_key, tee_pubkey, _network: std::marker::PhantomData }
     }
@@ -92,8 +92,8 @@ where
 fn decrypt_response(
     output: &Bytes,
     metadata: &seismic_alloy_consensus::TxSeismicMetadata,
-    tee_pubkey: &seismic_enclave::secp256k1::PublicKey,
-    provider_secret_key: &seismic_enclave::secp256k1::SecretKey,
+    tee_pubkey: &seismic_crypto::secp256k1::PublicKey,
+    provider_secret_key: &seismic_crypto::secp256k1::SecretKey,
 ) -> TransportResult<Bytes> {
     metadata
         .seismic_elements
@@ -231,15 +231,15 @@ where
 /// Layer that wraps a provider with [`ResponseDecryptProvider`].
 #[derive(Debug, Clone)]
 pub struct ResponseDecryptLayer {
-    provider_secret_key: seismic_enclave::secp256k1::SecretKey,
-    tee_pubkey: seismic_enclave::secp256k1::PublicKey,
+    provider_secret_key: seismic_crypto::secp256k1::SecretKey,
+    tee_pubkey: seismic_crypto::secp256k1::PublicKey,
 }
 
 impl ResponseDecryptLayer {
     /// Create a new response decrypt layer.
     pub fn new(
-        provider_secret_key: seismic_enclave::secp256k1::SecretKey,
-        tee_pubkey: seismic_enclave::secp256k1::PublicKey,
+        provider_secret_key: seismic_crypto::secp256k1::SecretKey,
+        tee_pubkey: seismic_crypto::secp256k1::PublicKey,
     ) -> Self {
         Self { provider_secret_key, tee_pubkey }
     }

--- a/crates/provider/src/tests.rs
+++ b/crates/provider/src/tests.rs
@@ -67,7 +67,7 @@ async fn test_get_tee_pubkey() {
         .unwrap();
 
     let tee_pubkey = provider.get_tee_pubkey().await.unwrap();
-    assert_eq!(tee_pubkey, seismic_enclave::get_unsecure_sample_secp256k1_pk());
+    assert_eq!(tee_pubkey, seismic_crypto::get_unsecure_sample_secp256k1_pk());
 }
 
 #[tokio::test]
@@ -783,10 +783,10 @@ async fn test_precompile_aes_encrypt_decrypt() {
 
     // 6. Cross-check: local AES decryption
     let secp_private =
-        seismic_enclave::secp256k1::SecretKey::from_slice(private_key.as_ref()).unwrap();
+        seismic_crypto::secp256k1::SecretKey::from_slice(private_key.as_ref()).unwrap();
     let aes_key: [u8; 32] = secp_private.secret_bytes()[0..32].try_into().unwrap();
     let nonce_bytes: [u8; 12] = nonce.to_be_bytes();
-    let decrypted_locally = seismic_enclave::aes_decrypt(&aes_key.into(), &ciphertext, nonce_bytes)
+    let decrypted_locally = seismic_crypto::aes_decrypt(&aes_key.into(), &ciphertext, nonce_bytes)
         .expect("Local AES decryption failed");
     assert_eq!(decrypted_locally, message, "Local decryption should match original message");
 
@@ -993,8 +993,8 @@ async fn test_precompile_ecdh() {
     // Use test keys
     let sk = hex!("7e38022030c40773cc561c1cc9c0053e48b0be2cee33c13495f096942ea176ef");
     let pk_secret =
-        seismic_enclave::secp256k1::SecretKey::from_slice(&sk).expect("valid secret key");
-    let pk_public = pk_secret.public_key(&seismic_enclave::secp256k1::Secp256k1::new());
+        seismic_crypto::secp256k1::SecretKey::from_slice(&sk).expect("valid secret key");
+    let pk_public = pk_secret.public_key(&seismic_crypto::secp256k1::Secp256k1::new());
     let pk_bytes = pk_public.serialize(); // 33 bytes compressed
 
     let sk_fixed = FixedBytes::<32>::from(sk);
@@ -1004,9 +1004,9 @@ async fn test_precompile_ecdh() {
     assert_ne!(result, FixedBytes::<32>::ZERO, "ECDH result should not be all zeros");
 
     // Cross-check: compute ECDH + HKDF locally and verify it matches
-    let shared_secret = seismic_enclave::secp256k1::ecdh::SharedSecret::new(&pk_public, &pk_secret);
+    let shared_secret = seismic_crypto::secp256k1::ecdh::SharedSecret::new(&pk_public, &pk_secret);
     let local_aes_key =
-        seismic_enclave::derive_aes_key(&shared_secret).expect("HKDF derivation failed");
+        seismic_crypto::derive_aes_key(&shared_secret).expect("HKDF derivation failed");
     assert_eq!(
         result.as_slice(),
         local_aes_key.as_slice(),
@@ -1075,16 +1075,16 @@ async fn test_precompile_secp256k1_sign() {
     // Cross-check: recover the signer's public key using ecrecover.
     // The precompile signs the raw 32-byte digest (no extra hashing).
     let sk =
-        seismic_enclave::secp256k1::SecretKey::from_slice(&sk_bytes).expect("valid secret key");
-    let expected_pk = sk.public_key(&seismic_enclave::secp256k1::Secp256k1::new()).serialize();
+        seismic_crypto::secp256k1::SecretKey::from_slice(&sk_bytes).expect("valid secret key");
+    let expected_pk = sk.public_key(&seismic_crypto::secp256k1::Secp256k1::new()).serialize();
 
-    let recoverable_sig = seismic_enclave::secp256k1::ecdsa::RecoverableSignature::from_compact(
+    let recoverable_sig = seismic_crypto::secp256k1::ecdsa::RecoverableSignature::from_compact(
         sig.signature.as_slice(),
-        seismic_enclave::secp256k1::ecdsa::RecoveryId::try_from(sig.recovery_id as i32).unwrap(),
+        seismic_crypto::secp256k1::ecdsa::RecoveryId::try_from(sig.recovery_id as i32).unwrap(),
     )
     .expect("valid recoverable signature");
-    let msg = seismic_enclave::secp256k1::Message::from_digest(*msg_hash);
-    let recovered = seismic_enclave::secp256k1::Secp256k1::new()
+    let msg = seismic_crypto::secp256k1::Message::from_digest(*msg_hash);
+    let recovered = seismic_crypto::secp256k1::Secp256k1::new()
         .recover_ecdsa(&msg, &recoverable_sig)
         .expect("recovery should succeed");
     assert_eq!(recovered.serialize(), expected_pk, "Recovered public key should match signer");

--- a/crates/provider/src/tests.rs
+++ b/crates/provider/src/tests.rs
@@ -1074,8 +1074,7 @@ async fn test_precompile_secp256k1_sign() {
 
     // Cross-check: recover the signer's public key using ecrecover.
     // The precompile signs the raw 32-byte digest (no extra hashing).
-    let sk =
-        seismic_crypto::secp256k1::SecretKey::from_slice(&sk_bytes).expect("valid secret key");
+    let sk = seismic_crypto::secp256k1::SecretKey::from_slice(&sk_bytes).expect("valid secret key");
     let expected_pk = sk.public_key(&seismic_crypto::secp256k1::Secp256k1::new()).serialize();
 
     let recoverable_sig = seismic_crypto::secp256k1::ecdsa::RecoverableSignature::from_compact(

--- a/crates/provider/src/traits.rs
+++ b/crates/provider/src/traits.rs
@@ -23,7 +23,7 @@ use seismic_alloy_network::{
     foundry::SeismicFoundry, seismic_network::SeismicNetwork, SeismicReth,
 };
 use seismic_alloy_rpc_types::SeismicTransactionRequest;
-use seismic_enclave::secp256k1::PublicKey;
+use seismic_crypto::secp256k1::PublicKey;
 
 // ============================================================================
 // SeismicProviderExt — base trait for all Seismic providers

--- a/crates/rpc-types/Cargo.toml
+++ b/crates/rpc-types/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 # Workspace
 seismic-alloy-consensus = { workspace = true, features = ["serde"] }
-seismic-enclave.workspace = true
+seismic-crypto.workspace = true
 
 # Alloy
 alloy-serde.workspace = true

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -228,7 +228,7 @@ impl SeismicTransactionRequest {
 
     fn decrypt_to_tx_request(
         &self,
-        secret_key: &seismic_enclave::secp256k1::SecretKey,
+        secret_key: &seismic_crypto::secp256k1::SecretKey,
     ) -> Result<TransactionRequest, InputDecryptionElementsError> {
         if self.seismic_elements.is_some() {
             let sender = match self.from {
@@ -254,7 +254,7 @@ impl SeismicTransactionRequest {
     /// Decrypts the seismic elements and returns a [`TransactionRequest`].
     pub fn to_transaction_request(
         &self,
-        secret_key: &seismic_enclave::secp256k1::SecretKey,
+        secret_key: &seismic_crypto::secp256k1::SecretKey,
     ) -> Result<TransactionRequest, InputDecryptionElementsError> {
         match self.transaction_type {
             Some(SEISMIC_TX_TYPE_ID) => {
@@ -747,7 +747,7 @@ mod tests {
             .seismic();
         req.inner.chain_id = Some(1);
 
-        let sk = seismic_enclave::get_unsecure_sample_secp256k1_sk();
+        let sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
         let result = req.to_transaction_request(&sk);
         assert!(result.is_err(), "to_transaction_request should return Err when input is missing");
     }


### PR DESCRIPTION
Replace direct seismic-enclave usage with seismic-crypto across consensus, network, provider, and rpc-types. Bump seismic-revm/revm to the commit that has also migrated off the enclave facade, and replace the enclave patch with a seismic-crypto patch.

Update CLAUDE.md to reflect the new crypto dependency.