### PR TITLE
fix(consensus): preserve traits for generic EIP-4844 transaction types

### DIFF
--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -126,8 +126,17 @@ impl From<Signed<TxSeismic>> for SeismicTxEnvelope {
     }
 }
 
-impl From<SeismicTxEnvelope> for Signed<SeismicTypedTransaction> {
-    fn from(value: SeismicTxEnvelope) -> Self {
+impl<Eip4844> From<SeismicTxEnvelope<Eip4844>> for Signed<SeismicTypedTransaction<Eip4844>>
+where
+    Eip4844: Transaction
+        + RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
+    fn from(value: SeismicTxEnvelope<Eip4844>) -> Self {
         match value {
             SeismicTxEnvelope::Legacy(tx) => {
                 let (tx, sig, hash) = tx.into_parts();
@@ -157,14 +166,32 @@ impl From<SeismicTxEnvelope> for Signed<SeismicTypedTransaction> {
     }
 }
 
-impl Hash for SeismicTxEnvelope {
+impl<Eip4844> Hash for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+    SeismicTxEnvelope<Eip4844>: Encodable2718,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.trie_hash().hash(state);
     }
 }
 
-impl From<Signed<SeismicTypedTransaction>> for SeismicTxEnvelope {
-    fn from(value: Signed<SeismicTypedTransaction>) -> Self {
+impl<Eip4844> From<Signed<SeismicTypedTransaction<Eip4844>>> for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: Transaction
+        + RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
+    fn from(value: Signed<SeismicTypedTransaction<Eip4844>>) -> Self {
         let (tx, sig, hash) = value.into_parts();
         match tx {
             SeismicTypedTransaction::Legacy(tx_legacy) => {
@@ -195,7 +222,16 @@ impl From<Signed<SeismicTypedTransaction>> for SeismicTxEnvelope {
     }
 }
 
-impl Typed2718 for SeismicTxEnvelope {
+impl<Eip4844> Typed2718 for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: Typed2718
+        + RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
     fn ty(&self) -> u8 {
         match self {
             Self::Legacy(tx) => tx.tx().ty(),
@@ -208,7 +244,16 @@ impl Typed2718 for SeismicTxEnvelope {
     }
 }
 
-impl Transaction for SeismicTxEnvelope {
+impl<Eip4844> Transaction for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: Transaction
+        + RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
     fn chain_id(&self) -> Option<u64> {
         match self {
             Self::Legacy(tx) => tx.tx().chain_id(),
@@ -408,7 +453,16 @@ impl Transaction for SeismicTxEnvelope {
     }
 }
 
-impl InputDecryptionElements for SeismicTxEnvelope {
+impl<Eip4844> InputDecryptionElements for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: Transaction
+        + RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
     fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError> {
         match self {
             Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
@@ -611,7 +665,15 @@ where
 }
 
 #[cfg(feature = "k256")]
-impl alloy_consensus::transaction::SignerRecoverable for SeismicTxEnvelope {
+impl<Eip4844> alloy_consensus::transaction::SignerRecoverable for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
     fn recover_signer(&self) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
         let signature_hash = match self {
             Self::Legacy(tx) => tx.signature_hash(),
@@ -653,7 +715,16 @@ impl alloy_consensus::transaction::SignerRecoverable for SeismicTxEnvelope {
     }
 }
 
-impl Encodable for SeismicTxEnvelope {
+impl<Eip4844> Encodable for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Typed2718
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
         self.network_encode(out)
     }
@@ -663,7 +734,16 @@ impl Encodable for SeismicTxEnvelope {
     }
 }
 
-impl Decodable for SeismicTxEnvelope {
+impl<Eip4844> Decodable for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Typed2718
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         Ok(Self::network_decode(buf)?)
     }
@@ -759,7 +839,16 @@ where
     }
 }
 
-impl Encodable2718 for SeismicTxEnvelope {
+impl<Eip4844> Encodable2718 for SeismicTxEnvelope<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Typed2718
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize
+        + SignableTransaction<Signature>,
+{
     fn type_flag(&self) -> Option<u8> {
         match self {
             Self::Legacy(_) => None,
@@ -939,6 +1028,12 @@ mod tests {
 
     #[cfg(feature = "serde")]
     use alloy_primitives::hex;
+
+    #[test]
+    fn generic_eip4844_variant_keeps_consensus_traits() {
+        fn assert_transaction<T: Transaction + Typed2718 + Encodable2718>() {}
+        assert_transaction::<TxEnvelope>();
+    }
 
     #[test]
     #[cfg(feature = "serde")]

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -205,7 +205,14 @@ where
     }
 }
 
-impl Typed2718 for SeismicTypedTransaction {
+impl<Eip4844> Typed2718 for SeismicTypedTransaction<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize,
+{
     fn ty(&self) -> u8 {
         match self {
             Self::Legacy(_) => SeismicTxType::Legacy as u8,
@@ -218,7 +225,15 @@ impl Typed2718 for SeismicTypedTransaction {
     }
 }
 
-impl Transaction for SeismicTypedTransaction {
+impl<Eip4844> Transaction for SeismicTypedTransaction<Eip4844>
+where
+    Eip4844: Transaction
+        + RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize,
+{
     fn chain_id(&self) -> Option<alloy_primitives::ChainId> {
         match self {
             Self::Legacy(tx) => tx.chain_id(),
@@ -418,7 +433,15 @@ impl Transaction for SeismicTypedTransaction {
     }
 }
 
-impl InputDecryptionElements for SeismicTypedTransaction {
+impl<Eip4844> InputDecryptionElements for SeismicTypedTransaction<Eip4844>
+where
+    Eip4844: Transaction
+        + RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize,
+{
     fn get_decryption_elements(&self) -> Result<TxSeismicElements, InputDecryptionElementsError> {
         match self {
             Self::Legacy(_) => Err(InputDecryptionElementsError::UnsupportedTxType(
@@ -487,7 +510,15 @@ impl InputDecryptionElements for SeismicTypedTransaction {
     }
 }
 
-impl RlpEcdsaEncodableTx for SeismicTypedTransaction {
+impl<Eip4844> RlpEcdsaEncodableTx for SeismicTypedTransaction<Eip4844>
+where
+    Eip4844: RlpEcdsaEncodableTx
+        + RlpEcdsaDecodableTx
+        + Typed2718
+        + Clone
+        + serde::de::DeserializeOwned
+        + serde::Serialize,
+{
     fn rlp_encoded_fields_length(&self) -> usize {
         match self {
             Self::Legacy(tx) => tx.rlp_encoded_fields_length(),


### PR DESCRIPTION
Fixes #55

## Summary

Complete the generic EIP-4844 trait surface for Seismic consensus transaction types so the non-default EIP-4844 representation used by `TxEnvelope` retains the same core traits as the default type.

This keeps the existing generic `SeismicTypedTransaction<Eip4844>` / `SeismicTxEnvelope<Eip4844>` design, but makes the relevant trait impls generic as well instead of only implementing them for the default `TxEip4844` parameter.

## Changes

- make the core consensus traits generic for `SeismicTypedTransaction<Eip4844>`
- make the corresponding envelope traits and conversions generic for `SeismicTxEnvelope<Eip4844>`
- add a compile-time regression test asserting `TxEnvelope` implements `Transaction + Typed2718 + Encodable2718`

## Why

`TxEnvelope` already uses `TxEip4844Variant`, while several trait impls were still written for the default type parameter. This left the generic enum available while the alternate EIP-4844 representation lost the trait surface needed by downstream reth/proptest code.

This follows the direction of the earlier WIP #54 without carrying over its unrelated dependency or network changes.

## Verification

Opening as draft so Seismic CI can run the authoritative formatting, build, warnings, unit, and integration checks before marking this ready for review.