### PR TITLE
docs(network): fix copy-pasted "Op-stack network" doc comments

### DIFF
--- a/crates/network/src/foundry/mod.rs
+++ b/crates/network/src/foundry/mod.rs
@@ -36,7 +36,7 @@ use crate::{
 /// Seismic foundry receipt response
 pub type SeismicFoundryReceiptResponse = WithOtherFields<SeismicTransactionReceipt>;
 
-/// Types for an Op-stack network.
+/// Types for the Seismic network when used with Foundry (anvil/cast) as the execution client.
 #[derive(Clone, Copy, Debug)]
 pub struct SeismicFoundry {
     _private: (),

--- a/crates/network/src/reth/mod.rs
+++ b/crates/network/src/reth/mod.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_eth::AccessList;
 use seismic_alloy_consensus::{SeismicTxEnvelope, SeismicTxType, SeismicTypedTransaction};
 use seismic_alloy_rpc_types::SeismicTransactionRequest;
 
-/// Types for an Op-stack network.
+/// Types for the Seismic network when used with reth as the execution client.
 #[derive(Clone, Copy, Debug)]
 pub struct SeismicReth {
     _private: (),


### PR DESCRIPTION
Both `SeismicReth` and `SeismicFoundry` carried the doc comment "Types for an Op-stack network." — verified this is the exact wording used by `op-alloy-network`'s own equivalent type (confirmed via its published docs), which confirms these were copied from an OP-stack-based alloy network implementation as a starting template, without updating the description for what they actually represent.

## Change
Replaces both with a description of what each struct actually is: the Seismic network types for the reth vs. Foundry (anvil/cast) execution-client backends respectively.

No logic changes — doc comments only, 2 files, 1 line each.
