### PR TITLE
chore(deps): bump seismic-crypto and seismic-revm (well-known key rename)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,33 +1642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version 0.4.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,12 +2039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,16 +2254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom_or_panic"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
-dependencies = [
- "rand 0.8.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2430,12 @@ checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
@@ -3195,18 +3158,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
 
 [[package]]
 name = "mio"
@@ -3939,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3957,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitvec",
  "phf",
@@ -3968,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3984,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.1.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3999,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -4012,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "either",
@@ -4024,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4042,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "either",
@@ -4059,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.2"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4071,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4095,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4106,7 +4057,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "bitflags 2.13.1",
  "revm-bytecode",
@@ -4392,27 +4343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnorrkel"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9fcb6c2e176e86ec703e22560d99d65a5ee9056ae45a08e13e84ebf796296f"
-dependencies = [
- "aead",
- "arrayref",
- "arrayvec",
- "cfg-if",
- "curve25519-dalek",
- "getrandom_or_panic",
- "merlin",
- "rand_core 0.6.4",
- "serde",
- "serde_bytes",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,13 +4554,13 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=7dc159d50f7142466e0ac5c73e15d524d996b5b2#7dc159d50f7142466e0ac5c73e15d524d996b5b2"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "hex-literal",
  "hkdf",
  "rand 0.9.5",
- "schnorrkel",
  "secp256k1 0.30.0",
  "serde",
  "sha2",
@@ -4682,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "seismic-revm"
 version = "1.0.0"
-source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=7fc2aee41fc8f9370b7103eb07068b4bdeba9729#7fc2aee41fc8f9370b7103eb07068b4bdeba9729"
+source = "git+https://github.com/SeismicSystems/seismic-revm.git?rev=45b4f4f036d324013636c9f3203012e58971c187#45b4f4f036d324013636c9f3203012e58971c187"
 dependencies = [
  "auto_impl",
  "hkdf",
@@ -4733,16 +4663,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 
 [patch.crates-io]
 # seismic-crypto
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "7dc159d50f7142466e0ac5c73e15d524d996b5b2" }
 
 # seismic-alloy-core
 alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }
@@ -173,5 +173,5 @@ alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy
 alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "2787e2265d492fa8eaee00424585b8f7e522178f" }
 
 # revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "7fc2aee41fc8f9370b7103eb07068b4bdeba9729" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "45b4f4f036d324013636c9f3203012e58971c187" }

--- a/crates/consensus/src/transaction/seismic.rs
+++ b/crates/consensus/src/transaction/seismic.rs
@@ -1149,7 +1149,7 @@ mod tests {
         hex::{self, FromHex},
         Address, FixedBytes, Signature,
     };
-    use seismic_crypto::{get_unsecure_sample_secp256k1_pk, get_unsecure_sample_secp256k1_sk};
+    use seismic_crypto::well_known_tx_io_keypair;
 
     use super::*;
 
@@ -1560,7 +1560,7 @@ mod tests {
         let seismic_elements = TxSeismicElements::default();
         let empty_bytes = Bytes::new();
 
-        let tx_io_sk = get_unsecure_sample_secp256k1_sk();
+        let tx_io_sk = well_known_tx_io_keypair().secret_key();
         let tx_metadata = TxSeismicMetadata::example(seismic_elements.clone(), sender);
 
         let result = seismic_elements.encrypt_response(&tx_io_sk, &empty_bytes, &tx_metadata);
@@ -1570,8 +1570,8 @@ mod tests {
 
     #[test]
     fn test_request_and_response_use_distinct_traffic_keys() {
-        let network_sk = get_unsecure_sample_secp256k1_sk();
-        let network_pk = get_unsecure_sample_secp256k1_pk();
+        let network_keypair = well_known_tx_io_keypair();
+        let (network_sk, network_pk) = (network_keypair.secret_key(), network_keypair.public_key());
         let client_sk = SecretKey::from_slice(&[1u8; 32]).unwrap();
         let client_pk = client_sk.public_key(&Secp256k1::new());
         let elements = TxSeismicElements {
@@ -1603,7 +1603,7 @@ mod tests {
         // similar test to seismic-viem-test's trace.ts
         let plaintext = Bytes::from_str("0xdeadbeef").unwrap();
         let seismic_elements = TxSeismicElements {
-            encryption_pubkey: get_unsecure_sample_secp256k1_pk(),
+            encryption_pubkey: well_known_tx_io_keypair().public_key(),
             encryption_nonce: U96::MAX,
             message_version: 0,
             recent_block_hash: FixedBytes::<32>::from_str(
@@ -1613,7 +1613,7 @@ mod tests {
             expires_at_block: 100,
             signed_read: false,
         };
-        let secret_key = get_unsecure_sample_secp256k1_sk();
+        let secret_key = well_known_tx_io_keypair().secret_key();
         let orig_decoded_tx = TxSeismic {
             chain_id: 31337u64,
             nonce: 0,
@@ -1633,7 +1633,7 @@ mod tests {
         let encrypted_calldata = seismic_elements
             .client_encrypt(
                 &plaintext,
-                &get_unsecure_sample_secp256k1_pk(),
+                &well_known_tx_io_keypair().public_key(),
                 &secret_key,
                 &tx_metadata,
             )

--- a/crates/provider/src/tests.rs
+++ b/crates/provider/src/tests.rs
@@ -67,7 +67,7 @@ async fn test_get_tee_pubkey() {
         .unwrap();
 
     let tee_pubkey = provider.get_tee_pubkey().await.unwrap();
-    assert_eq!(tee_pubkey, seismic_crypto::get_unsecure_sample_secp256k1_pk());
+    assert_eq!(tee_pubkey, seismic_crypto::well_known_tx_io_keypair().public_key());
 }
 
 #[tokio::test]

--- a/crates/rpc-types/src/transaction/request.rs
+++ b/crates/rpc-types/src/transaction/request.rs
@@ -748,7 +748,7 @@ mod tests {
             .seismic();
         req.inner.chain_id = Some(1);
 
-        let sk = seismic_crypto::get_unsecure_sample_secp256k1_sk();
+        let sk = seismic_crypto::well_known_tx_io_keypair().secret_key();
         let result = req.to_transaction_request(&sk);
         assert!(result.is_err(), "to_transaction_request should return Err when input is missing");
     }


### PR DESCRIPTION
Part of SEI-172

seismic-crypto renamed its well-known network key getters for what they are (SeismicSystems/enclave#262): these are the keys every network without a root key actually runs, not test fixtures. The tests here take the rename: well_known_tx_io_keypair() replaces the split sk/pk getters, so a mismatched pair is unrepresentable, and the tee-pubkey test still matches the key sanvil serves — the values are unchanged.

The seismic-revm pin moves to the rev that takes the same rename (SeismicSystems/seismic-revm#239): the [patch.crates-io] seismic-crypto override applies to seismic-revm's build too, so both pins advance together.