### PR TITLE
fix(consensus): SeismicTxType::ALL is missing Eip4844

### DIFF
--- a/crates/consensus/src/transaction/tx_type.rs
+++ b/crates/consensus/src/transaction/tx_type.rs
@@ -45,8 +45,14 @@ pub enum SeismicTxType {
 
 impl SeismicTxType {
     /// List of all variants.
-    pub const ALL: [Self; 5] =
-        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Seismic];
+    pub const ALL: [Self; 6] = [
+        Self::Legacy,
+        Self::Eip2930,
+        Self::Eip1559,
+        Self::Eip4844,
+        Self::Eip7702,
+        Self::Seismic,
+    ];
 }
 
 #[cfg(feature = "arbitrary")]
@@ -157,11 +163,12 @@ mod tests {
 
     #[test]
     fn test_all_tx_types() {
-        assert_eq!(SeismicTxType::ALL.len(), 5);
+        assert_eq!(SeismicTxType::ALL.len(), 6);
         let all = vec![
             SeismicTxType::Legacy,
             SeismicTxType::Eip2930,
             SeismicTxType::Eip1559,
+            SeismicTxType::Eip4844,
             SeismicTxType::Eip7702,
             SeismicTxType::Seismic,
         ];


### PR DESCRIPTION
Closes #116.

`SeismicTxType::ALL` listed only 5 of the enum's 6 variants — `Eip4844` was missing.

## Impact
`ALL` is only consumed within this crate's own test suite:
- `test_all_tx_types` asserted `ALL.len() == 5`, only self-consistent because `ALL` itself was incomplete.
- `tx_type_roundtrip` iterates `ALL` to encode/decode-roundtrip every variant — since `Eip4844` wasn't in `ALL`, its roundtrip was silently never exercised by this test.

Found while investigating a related `test_roundtrip_2718` in `seismic-reth` (`crates/seismic/primitives/src/transaction/signed.rs`) that explicitly skips `Eip4844` with the comment `// TODO: make this work for eip4844 in seismic-alloy`. This `ALL` gap may be a contributing factor to that known issue, though I haven't traced the full root cause of that broader TODO.

Every other place in the codebase that matches on `SeismicTxType` (`envelope.rs`, `typed.rs`, `receipt/envelope.rs`, seismic-reth's `receipt.rs`/`transaction/signed.rs`, `storage/codecs`) handles `Eip4844` correctly — this `ALL` constant was an isolated oversight, not a systemic pattern.

## Change
Adds `Eip4844` to `ALL` in enum declaration order, and updates `test_all_tx_types`'s expected list/length accordingly.

## Related
Opened a companion PR in `seismic-evm` for a related gap this same investigation turned up (`SeismicAlloyReceiptBuilder` panicking on `Eip4844`).
